### PR TITLE
✨ [Feat] Spring Security 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,11 @@ dependencies {
 	// STOMP
 	implementation 'org.webjars:stomp-websocket:2.3.4'
 
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.1.RELEASE'
+
 	// 테스트 의존성
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
+++ b/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.backend.farmon.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@RequiredArgsConstructor
+@EnableWebSecurity // Spring Security 설정 활성화
+@Configuration
+public class SecurityConfig { // 애플리케이션의 보안 정책을 정의
+
+    // SecurityFilterChain 정의
+    // 추후에 농업인 관련 페이지는 농업인만, 전문가 관련 페이지는 전문가만 가입할 수 있도록 수정 필요
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests((requests) -> requests
+                        .anyRequest().permitAll() // 모든 요청을 인증 없이 접근 가능하도록 설정
+                )
+                .csrf().disable(); // 필요 시 CSRF 보호 비활성화
+
+        return http.build();
+    }
+
+    // 비밀번호 암호화
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #7

## 📝작업 내용

1차 과제에 Spring Securtity 설정 코드까지 추가해야 하여 관련 코드인 `SpringConfig` 클래스를 추가하였습니다.
아직 API 명세서 작성 단계이기 때문에, JWT 인증 & 인가 설정은 추가하지 않았고, 모든 요청을 인증 없이 접근 가능하도록 permitAll()로 설정하였습니다. 
추후에 농업인 관련 페이지는 농업인만 접근 가능하도록, 전문가 관련 페이지는 전문가만 접근 가능하도록 수정이 필요할 것 같습니다.
