### PR TITLE
✨ [Feat] 전문가 프로필 목록/내 프로필 페이지 API 명세서 작성

### DIFF
--- a/src/main/java/com/backend/farmon/controller/ExpertController.java
+++ b/src/main/java/com/backend/farmon/controller/ExpertController.java
@@ -1,0 +1,51 @@
+package com.backend.farmon.controller;
+
+import com.backend.farmon.apiPayload.ApiResponse;
+import com.backend.farmon.dto.expert.ExpertListResponse;
+import com.backend.farmon.dto.expert.ExpertProfileResponse;
+import com.backend.farmon.dto.user.MypageRequest;
+import com.backend.farmon.dto.user.MypageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "전문가")
+@RestController
+@RequiredArgsConstructor
+public class ExpertController {
+
+    // 전문가 프로필 목록 조회
+    @GetMapping("/expert")
+    @Operation(
+            summary = "전문가 프로필 목록 조회 API",
+            description = "전문가 프로필 목록을 조회하는 API이며, 페이징을 포함합니다. " +
+                    "서비스, 지역, 페이지를 query String 으로 주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "service", description = "전문가 서비스 필터링"),
+            @Parameter(name = "area", description = "전문가 지역 필터링"),
+            @Parameter(name = "page", description = "페이지 번호, 1부터 시작입니다.", example = "1", required = true)
+    })
+    public ApiResponse<ExpertListResponse.ExpertProfileListDTO> getExpertList (@RequestParam(name = "service") Long service,
+                                                                               @RequestParam(name = "area") String area,
+                                                                               @RequestParam(name = "page")  Integer page){
+        return null;
+    }
+
+    // 전문가 내 프로필 페이지 조회
+    @PatchMapping("/expert/{id}")
+    @Operation(summary = "전문가 내 프로필 페이지 조회 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<ExpertProfileResponse.ExpertProfileDTO> getExpertProfilePage(@PathVariable Long id) {
+        return null;
+    }
+}

--- a/src/main/java/com/backend/farmon/controller/ExpertController.java
+++ b/src/main/java/com/backend/farmon/controller/ExpertController.java
@@ -18,6 +18,18 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ExpertController {
 
+    // 전문가 내 프로필 페이지 조회
+    @GetMapping("/expert/{expert-id}")
+    @Operation(summary = "전문가 내 프로필 페이지 조회 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<ExpertProfileResponse.ExpertProfileDTO> getExpertProfilePage(
+            @Parameter(name = "expert-id", description = "전문가 아이디")
+            @PathVariable(name = "expert-id") Long expertId) {
+        return null;
+    }
+
     // 전문가 프로필 목록 조회
     @GetMapping("/expert")
     @Operation(
@@ -39,13 +51,4 @@ public class ExpertController {
         return null;
     }
 
-    // 전문가 내 프로필 페이지 조회
-    @PatchMapping("/expert/{id}")
-    @Operation(summary = "전문가 내 프로필 페이지 조회 API")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-    })
-    public ApiResponse<ExpertProfileResponse.ExpertProfileDTO> getExpertProfilePage(@PathVariable Long id) {
-        return null;
-    }
 }

--- a/src/main/java/com/backend/farmon/dto/expert/ExpertListResponse.java
+++ b/src/main/java/com/backend/farmon/dto/expert/ExpertListResponse.java
@@ -1,0 +1,67 @@
+package com.backend.farmon.dto.expert;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class ExpertListResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "전문가 프로필 목록")
+    public static class ExpertProfileListDTO {
+        @Schema(description = "전문가 프로필 목록")
+        List<ExpertProfileViewDTO> expertProfileList;
+
+        @Schema(description = "목록 개수")
+        Integer listSize;
+
+        @Schema(description = "전체 페이지 수")
+        Integer totalPage;
+
+        @Schema(description = "전체 프로필 개수")
+        Long totalElements;
+
+        @Schema(description = "첫 페이지인지 확인")
+        Boolean isFirst;
+
+        @Schema(description = "마지막 페이지인지 확인")
+        Boolean isLast;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ExpertProfileViewDTO {
+        @Schema(description = "프로필 이미지")
+        String profileImg;
+
+        @Schema(description = "이름")
+        String name;
+
+        @Schema(description = "평점")
+        Float rate;
+
+        @Schema(description = "경력")
+        Integer career;
+
+        @Schema(description = "전문가 한 줄 소개")
+        String expertDescription;
+
+        @Schema(description = "전문가 전문 분야 카테고리 리스트")
+        List<Long> expertCrops;
+
+        @Schema(description = "전문가 활동 위치 카테고리 리스트")
+        List<Long> expertLocations;
+
+        LocalDate createdAt; // 기본 정렬 전문가 가입날짜순
+    }
+}

--- a/src/main/java/com/backend/farmon/dto/expert/ExpertListResponse.java
+++ b/src/main/java/com/backend/farmon/dto/expert/ExpertListResponse.java
@@ -41,6 +41,9 @@ public class ExpertListResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ExpertProfileViewDTO {
+        @Schema(description = "전문가 아이디")
+        Long expertId;
+
         @Schema(description = "프로필 이미지")
         String profileImg;
 

--- a/src/main/java/com/backend/farmon/dto/expert/ExpertProfileResponse.java
+++ b/src/main/java/com/backend/farmon/dto/expert/ExpertProfileResponse.java
@@ -1,0 +1,68 @@
+package com.backend.farmon.dto.expert;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class ExpertProfileResponse {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ExpertProfileDTO {
+        @Schema(description = "프로필 이미지")
+        String profileImg;
+
+        @Schema(description = "이름")
+        String name;
+
+        @Schema(description = "본인인증 여부")
+        Boolean isVerified;
+
+        @Schema(description = "전문가 한 줄 소개")
+        String expertDescription;
+
+        @Schema(description = "평점")
+        Float rate;
+
+        @Schema(description = "진행했던 컨설팅 수")
+        Integer consultingCount;
+
+        @Schema(description = "경력")
+        Integer career;
+
+        @Schema(description = "추가정보")
+        String extraDetails;
+
+        @Schema(description = "포트폴리오 목록 리스트")
+        List<PortfolioDetailDTO> portfolio;
+
+        @Schema(description = "전문가 전문 분야 카테고리 리스트")
+        List<Long> expertCrops;
+
+        @Schema(description = "전문가 활동 위치 카테고리 리스트")
+        List<Long> expertLocations;
+
+        @Schema(description = "활동 가능 범위")
+        Integer availableRange;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PortfolioDetailDTO {
+        @Schema(description = "포트폴리오 썸네일 이미지")
+        String thumbnailImg;
+
+        @Schema(description = "포트폴리오 제목")
+        String name;
+
+        LocalDate createdAt; // 기본 정렬 생성 날짜순
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #15 

## 📝작업 내용

전문가 프로필 목록과 내 프로필 페이지(전문가 전용 프로필 페이지) DTO와 Controller 작성하였습니다.
와이어프레임만 보면 좀 헷갈리는 부분이 많아 제가 임의로 지정한 사항들이 있는데 나중에 제가 회의때 PM님께 여쭤보고 수정해놓겠습니다.
1. 전문가 프로필 페이지 서비스 필터링이 작물인지 컨설팅 분야인지 확실치 않아 일단 작물이라 생각하고 작성하였습니다.
2. 내 프로필 페이지 대표 서비스에 곡물 말고도 컨설팅 분야 (ex.농경지 스마트팜) 같은 정보도 껴 있는데, 컨설팅 분야는 언제 입력받는 정보인지 나와았지 않아서 카테고리 리스트로 받아야 할지 String으로 받아야 할지 헷갈려서... 일단은 와이어프레임 나오면 추가 작성하겠습니다. (만약 지역처럼 고르는 정보라면 전문가랑 매핑되는 컨설팅 분야 카테고리 엔티티를 또 만들어야 할 것 같습니다...)  

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/286bc10d-986e-428e-8fc1-32318d4364af)

## 💬리뷰 요구사항(선택)
> 저도 작성하면서 조금 헷갈려서 이상한 부분이나 부족한 사항 있으면 신경쓰지말고 피드백 해 주셔도 괜찮습니다!