### PR TITLE
✨ [Feat] 홈 화면 조회, 검색어 삭제 관련 API 명세서 작성

### DIFF
--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -1,0 +1,42 @@
+package com.backend.farmon.controller;
+
+import com.backend.farmon.apiPayload.ApiResponse;
+import com.backend.farmon.dto.chat.ChatResponse;
+import com.backend.farmon.dto.home.HomeResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "홈 화면", description = "홈 화면에 관한 API")
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/home")
+public class HomeController {
+
+    // 홈 화면 조회
+    @Operation(
+            summary = "홈 화면 조회 API",
+            description = "홈 화면 로딩에 필요한 정보를 조회합니다. 로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
+            @Parameter(name = "category", description = " 커뮤니티 카테고리", example = "인기", required = true)
+    })
+    @GetMapping("")
+    public ApiResponse<HomeResponse.HomePageDTO> getChatRoomPage (@RequestParam(name = "userId", required = false) Long userId,
+                                                                  @RequestParam(name = "category") String category){
+        return null;
+    }
+}

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -1,7 +1,6 @@
 package com.backend.farmon.controller;
 
 import com.backend.farmon.apiPayload.ApiResponse;
-import com.backend.farmon.dto.chat.ChatResponse;
 import com.backend.farmon.dto.home.HomeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -29,11 +28,45 @@ public class HomeController {
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1"),
-            @Parameter(name = "category", description = " 커뮤니티 카테고리 이름", example = "인기", required = true)
+            @Parameter(name = "category", description = "커뮤니티 카테고리 이름", example = "인기", required = true)
     })
     @GetMapping("")
     public ApiResponse<HomeResponse.HomePageDTO> getChatRoomPage (@RequestParam(name = "userId", required = false) Long userId,
                                                                   @RequestParam(name = "category") String category){
+        return null;
+    }
+
+    // 검색어 삭제 API
+    @Operation(
+            summary = "홈 화면에서 특정 검색어 삭제 API",
+            description = "홈 화면에서 특정 검색어를 삭제하는 API 입니다. 유저 아이디와 삭제할 검색어 이름을 쿼리 스트링으로 입력해 주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
+            @Parameter(name = "name", description = "삭제 할 검색어 이름", example = "병충해 관리")
+    })
+    @DeleteMapping("/search")
+    public ApiResponse<HomeResponse.HomePageDTO> deleteSearchName(@RequestParam(name = "userId") Long userId,
+                                                                  @RequestParam(name = "name") String searchName){
+        return null;
+    }
+
+    // 검색어 전체 삭제 API
+    @Operation(
+            summary = "홈 화면에서 사용자의 검색어를 전체 삭제 API",
+            description = "홈 화면에서 사용자의 검색어를 전체 삭제 API. 유저 아이디를 쿼리 스트링으로 입력해 주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1")
+    })
+    @DeleteMapping("/search/all")
+    public ApiResponse<HomeResponse.HomePageDTO> deleteAllSearchName(@RequestParam(name = "userId") Long userId){
         return null;
     }
 }

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -36,7 +36,7 @@ public class HomeController {
         return null;
     }
 
-    // 검색어 삭제 API
+    // 특정 검색어 삭제 API
     @Operation(
             summary = "홈 화면에서 특정 검색어 삭제 API",
             description = "홈 화면에서 특정 검색어를 삭제하는 API 입니다. 유저 아이디와 삭제할 검색어 이름을 쿼리 스트링으로 입력해 주세요."
@@ -63,10 +63,10 @@ public class HomeController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
     })
     @Parameters({
-            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1")
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1")
     })
     @DeleteMapping("/search/all")
-    public ApiResponse<HomeResponse.HomePageDTO> deleteAllSearchName(@RequestParam(name = "userId") Long userId){
+    public ApiResponse<HomeResponse.HomePageDTO> deleteAllSearchName(@RequestParam(name = "userId") Long userId) {
         return null;
     }
 }

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -10,10 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "홈 화면", description = "홈 화면에 관한 API")
 @Slf4j
@@ -31,8 +28,8 @@ public class HomeController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
     })
     @Parameters({
-            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
-            @Parameter(name = "category", description = " 커뮤니티 카테고리", example = "인기", required = true)
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1"),
+            @Parameter(name = "category", description = " 커뮤니티 카테고리 이름", example = "인기", required = true)
     })
     @GetMapping("")
     public ApiResponse<HomeResponse.HomePageDTO> getChatRoomPage (@RequestParam(name = "userId", required = false) Long userId,

--- a/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
+++ b/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
@@ -1,0 +1,78 @@
+package com.backend.farmon.dto.home;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+public class HomeResponse {
+    @ToString
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "홈 페이지 조회 정보")
+    public static class HomePageDTO {
+
+        @Schema(description = "커뮤니티 카테고리에 따른 게시글 리스트")
+        List <PostDetailDTO> postList;
+
+        @Schema(description = "커뮤니티 카테고리에 따른 게시글 리스트")
+        List <PopularPostDetailDTO> popularPostList;
+
+        @Schema(description = "최근 검색어 리스트")
+        List <String> recentSearchList;
+
+        @Schema(description = "추천 검색어 리스트")
+        List <String> recommendSearchList;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "홈 페이지 커뮤니티 게시글 정보")
+    public static class PostDetailDTO {
+
+        @Schema(description = "커뮤니티 카테고리", example = "Q&A")
+        String category;
+
+        @Schema(description = "커뮤니티 게시글 제목")
+        String postTitle;
+
+        @Schema(description = "커뮤니티 게시글 내용")
+        String postContent;
+
+        @Schema(description = "게시글 좋아요 횟수", example = "5")
+        Integer likeCount;
+
+        @Schema(description = "게시글 댓글 횟수", example = "2")
+        Integer commentCount;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "홈 페이지 인기 칼럼 정보")
+    public static class PopularPostDetailDTO {
+
+        @Schema(description = "인기 칼럼 제목")
+        String popularPostTitle;
+
+        @Schema(description = "인기 칼럼 내용")
+        String popularPostContent;
+
+        @Schema(description = "작성자 이름")
+        String writer;
+
+        @Schema(description = "작성자 프로필 이미지")
+        String profileImage;
+
+        @Schema(description = "인기 칼럼 썸네일 이미지")
+        String popularPostImage;
+    }
+}

--- a/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
+++ b/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
@@ -15,6 +15,12 @@ public class HomeResponse {
     @Schema(description = "홈 페이지 조회 정보")
     public static class HomePageDTO {
 
+        @Schema(description = "로그인한 사용자의 이름, 로그인 하지 않은 사용자일 경우 null", example = "김팜온")
+        String name;
+
+        @Schema(description = "로그인한 사용자의 유형(농업인 or 전문가), 로그인 하지 않은 사용자일 경우 null", example = "농업인")
+        String type;
+
         @Schema(description = "커뮤니티 카테고리에 따른 게시글 리스트")
         List <PostDetailDTO> postList;
 


### PR DESCRIPTION
## #️⃣연관된 이슈
- #19 
- #20

## 📝작업 내용
- 홈 화면 조회 API 명세서를 작성했습니다.
  - 로그인 하지 않은 사용자 일 경우 파라미터에 userId를 입력하지 않도록 작성하였습니다. 
- 특정 검색어 삭제 API 명세서를 작성했습니다. 
  - 로그인 하지 않은 사용자도 검색어를 삭제하는 것은 가능하도록 판단하여, 로그인 하지 않은 사용자일 경우에는 파라미터에 userId를 입력하지 않도록 작성하였습니다. 
- 검색어를 전체 삭제하는 API 명세서를 작성했습니다. 
- 검색어로 커뮤니티 게시글을 조회하는 부분은 커뮤니티 상세 와이어프레임이 나오는대로 추가하겠습니다.

### 스크린샷
<img width="1096" alt="image" src="https://github.com/user-attachments/assets/bbbec32e-c0c7-4a6c-a194-a5c45bc5f076" />


## 💬리뷰 요구사항
1. 로그인 여부에 관계 없이 인기 컬럼이나 커뮤니티 게시글 정보는 동일하다고 판단하여 홈 화면 조회 엔드포인트는 동일하고, 파라미터에 값에 따라 사용자의 최근 검색어 & 추천 검색어 리스트와 사용자 정보(이름, 타입)를 반환하도록 구현하면 될 것 같은데 다른 분들은 어떻게 생각하시는지 궁금합니다.
2. 사용자의 최근 검색어 삭제와 검색어 전체 삭제 모두 delete 메서드를 사용하기 때문에, 엔드포인트를 동일하게 두고 파라미터 값에 따라 최근 나누어 구현하도록 할까 고민하다가, 전체 삭제라는 것을 명확하게 표현되는 것이 좋을 것 같다고 생각해 엔드포인트를 다르게 두었습니다. 
3. 검색어 삭제 관련 API에서 로그인 하지 않은 사용자일 경우도 고려하여야 할 지 고민이 됩니다. 일단은 로그인한 사용자일 경우에만 검색 관련 데이터가 Redis 등에 저장될 것이라고 판단하고 작성해 보았습니다.
4. 검색어는 따로 엔티티를 만들어 MySQL에 저장하는 것보다, **Redis**와 같은 **NoSQL**에 저장하는 것이 좋을 것 같습니다. 이 부분은 구현할 때 다시 의견 나눠보면 좋을 것 같습니다.
