### PR TITLE
✨ [Feat] 농업인 전환, 전문가 전환 API 명세서 작성

### DIFF
--- a/src/main/java/com/backend/farmon/controller/UserController.java
+++ b/src/main/java/com/backend/farmon/controller/UserController.java
@@ -1,15 +1,18 @@
 package com.backend.farmon.controller;
 
 import com.backend.farmon.apiPayload.ApiResponse;
+import com.backend.farmon.dto.user.ExchangeResponse;
 import com.backend.farmon.dto.user.MypageRequest;
 import com.backend.farmon.dto.user.MypageResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "사용자 정보 설정")
+@Tag(name = "사용자 정보")
 @RestController
 @RequiredArgsConstructor
 public class UserController {
@@ -38,4 +41,21 @@ public class UserController {
         return null;
     }
 
+    @PatchMapping("/user/exchange")
+    @Operation(
+            summary = "사용자 역할 전환 API",
+            description = "농업인 전환과 전문가 전환에 관한 API 입니다. 농업인일 경우 전문가로 전환, 전문가일 경우 농업인으로 전환됩니다. " +
+                    "유저 아이디, 사용자 유형을 쿼리 스트링으로 입력해주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
+            @Parameter(name = "type", description = "사용자 유형(농업인 or 전문가)", example = "농업인")
+    })
+    public ApiResponse<ExchangeResponse> patchUserRole(@RequestParam(name="userId") Long userId,
+                                                       @RequestParam(name="type") String type) {
+        return null;
+    }
 }

--- a/src/main/java/com/backend/farmon/controller/UserController.java
+++ b/src/main/java/com/backend/farmon/controller/UserController.java
@@ -52,7 +52,7 @@ public class UserController {
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
-            @Parameter(name = "type", description = "사용자 유형(농업인 or 전문가)", example = "농업인")
+            @Parameter(name = "type", description = "전환하고자 하는 사용자 유형(전문가 전환 시 전문가 입력, 농업인 전환 시 농업인 입력)", example = "전문가")
     })
     public ApiResponse<ExchangeResponse> patchUserRole(@RequestParam(name="userId") Long userId,
                                                        @RequestParam(name="type") String type) {

--- a/src/main/java/com/backend/farmon/dto/user/ExchangeResponse.java
+++ b/src/main/java/com/backend/farmon/dto/user/ExchangeResponse.java
@@ -1,0 +1,8 @@
+package com.backend.farmon.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class ExchangeResponse {
+    @Schema(description = "전환 성공 여부, 성공일 경우 true", example = "true")
+    private Boolean isExchange;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #22

## 📝작업 내용
농업인 전환, 전문가 전환 API 명세서를 작성하였습니다. 파라미터에 userId와 전환하고자 하는 type(전문가 전환일 경우 전문가 입력, 농업인 전환일 경우 농업인 입력) 을 입력하도록 구현하였습니다.
응답 데이터는 마땅히 무엇을 넣어야 할 지 모르겠어서, 전환 성공 여부를 반환하도록 하였습니다.

### 스크린샷
<img width="854" alt="image" src="https://github.com/user-attachments/assets/09268038-991f-4b9f-84a8-c40b1d49d58a" />
