### PR TITLE
댓글과 대댓글에 대한 API작성

### DIFF
--- a/src/main/java/com/backend/farmon/BaseEntity.java
+++ b/src/main/java/com/backend/farmon/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.backend.farmon;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt; // 생성 시간
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt; // 수정 시간
+}

--- a/src/main/java/com/backend/farmon/controller/CommentController.java
+++ b/src/main/java/com/backend/farmon/controller/CommentController.java
@@ -1,0 +1,196 @@
+package com.backend.farmon.controller;
+
+import com.backend.farmon.apiPayload.ApiResponse;
+import com.backend.farmon.apiPayload.code.status.SuccessStatus;
+import com.backend.farmon.dto.Comment.CommentRequestDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+
+@Tag(name = "댓글 페이지", description = "댓글에 관한 API")
+@Controller
+@RequestMapping("/posts/{postNo}/comments")
+public class CommentController {
+
+    @Operation(summary = "댓글 저장", description = "사용자가 그냥 부모 댓글(댓글)을 저장합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "postNo", description = "게시물번호", required = true),
+            @Parameter(name = "CommentRequestDTO", description = "댓글 정보", required = true),
+    })
+    @PostMapping("/save")
+    public ApiResponse saveComment(@PathVariable Long postNo, @RequestBody @Valid CommentRequestDTO request) {
+        String resultcode = SuccessStatus._OK.getCode();
+        String resultmsg = SuccessStatus._OK.getMessage();
+
+        return new ApiResponse<>(true, resultcode, resultmsg);
+    }
+
+
+    @Operation(summary = "대댓글 저장", description = "사용자가 대댓글을 저장합니다..")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "postNo", description = "게시물번호", required = true),
+            @Parameter(name = "parentNo", description = "부모댓글저장", required = true),
+            @Parameter(name = "CommentSaveChildRequestDto", description = "대댓글 정보", required = true),
+    })
+    @PostMapping("/{parentNo}/save")
+    public ApiResponse saveChildComment(@PathVariable Long postNo, @PathVariable Long parentNo, @RequestBody @Valid CommentRequestDTO.CommentSaveChildRequestDto request) {
+        String resultcode = SuccessStatus._OK.getCode();
+        String resultmsg = SuccessStatus._OK.getMessage();
+
+        return new ApiResponse<>(true, resultcode, resultmsg);
+    }
+
+
+    @Operation(summary = "부모 댓글 조회", description = "사용자가 댓글(부모 댓글)을 조회합니다..")
+
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+            })
+    @Parameters({
+            @Parameter(name = "postNo", description = "게시물번호", required = true),
+            })
+    @GetMapping
+    public ApiResponse getParentComments(@PathVariable Long postNo) {
+        String resultcode = SuccessStatus._OK.getCode();
+        String resultmsg = SuccessStatus._OK.getMessage();
+
+        return new ApiResponse<>(true, resultcode, resultmsg);
+    }
+
+
+
+    @Operation(summary = "특정 댓글의 대댓글(자식 댓글) 조회", description = "사용자가 부모 댓글의 대댓글(자식 댓글) 조회합니다..")
+
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "postNo", description = "게시물번호", required = true),
+            @Parameter(name = "commentNo", description = "부모댓글번호", required = true),
+    })
+    @GetMapping("/{commentNo}/children")
+    public ApiResponse getChildComments(@PathVariable Long postNo, @PathVariable Long commentNo) {
+        String resultcode = SuccessStatus._OK.getCode();
+        String resultmsg = SuccessStatus._OK.getMessage();
+
+        return new ApiResponse<>(true, resultcode, resultmsg);
+    }
+
+    /**
+     * 댓글 한 개 상세 조회
+     */
+    @Operation(summary = "댓글 한 개 상세 조회", description = "사용자가 댓글 한 개 상세 조회합니다..")
+
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "postNo", description = "게시물번호", required = true),
+            @Parameter(name = "commentNo", description = "부모댓글번호", required = true)
+    })
+    @GetMapping("/{commentNo}/detail")
+    public ApiResponse getComment(@PathVariable Long postNo,@PathVariable Long commentNo) {
+        String resultcode = SuccessStatus._OK.getCode();
+        String resultmsg = SuccessStatus._OK.getMessage();
+
+        return new ApiResponse<>(true, resultcode, resultmsg);
+    }
+
+    /**
+     * 게시글의 모든 댓글 조회 (부모 + 자식 모두)
+     */
+    @Operation(summary = "게시글의 모든 댓글 조회", description = "사용자가 게시글의 모든 댓글 조회합니다..")
+
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "postNo", description = "게시물번호", required = true),
+    })
+    @GetMapping("/all")
+    public ApiResponse getAllComments(@PathVariable Long postNo) {
+        String resultcode = SuccessStatus._OK.getCode();
+        String resultmsg = SuccessStatus._OK.getMessage();
+
+        return new ApiResponse<>(true, resultcode, resultmsg);
+    }
+
+
+    @Operation(summary = "게시글의 부모 댓글(댓글) 수정", description = "사용자가 게시글의 부모 댓글 수정합니다..")
+
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "commentNo", description = "부모댓글번호", required = true),
+            @Parameter(name = "commentNo", description = "대댓글번호", required = true),
+            @Parameter(name = "CommentUpdateRequestDto", description = "댓글내용 수정", required = true),
+    })
+    @PutMapping("/{commentNo}")
+    public ApiResponse updateComment(@PathVariable Long postNo,@PathVariable Long commentNo, @RequestBody @Valid CommentRequestDTO.CommentUpdateRequestDto request) {
+        String resultcode = SuccessStatus._OK.getCode();
+        String resultmsg = SuccessStatus._OK.getMessage();
+
+        return new ApiResponse<>(true, resultcode, resultmsg);
+    }
+
+
+
+
+    @Operation(summary = "게시글의 대댓글  수정", description = "사용자가 게시글의 대댓글 수정합니다..")
+
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "parentNo", description = "부모댓글번호", required = true),
+            @Parameter(name = "commentNo", description = "대댓글번호", required = true),
+            @Parameter(name = "CommentUpdateRequestDto", description = "댓글내용 수정", required = true),
+
+    })
+    @PutMapping("/{parentNo}/children/{commentNo}")
+    public ApiResponse updateChildComment(@PathVariable Long postNo, @PathVariable Long parentNo, @PathVariable Long commentNo,
+                                          @RequestBody @Valid CommentRequestDTO.CommentUpdateRequestDto request) {
+        String resultCode = SuccessStatus._OK.getCode();
+        String resultMsg = SuccessStatus._OK.getMessage();
+
+        try {
+            // 대댓글 수정 서비스 호출
+            // commentService.updateChildComment(postNo, parentNo, commentNo, request); (서비스 호출 부분)
+            resultCode = SuccessStatus._OK.getCode();
+            resultMsg = "대댓글 수정이 완료되었습니다.";
+        } catch (Exception e) {
+            resultCode = "ERROR"; // 오류 코드
+            resultMsg = "대댓글 수정에 실패했습니다.";
+        }
+
+        return new ApiResponse<>(true, resultCode, resultMsg);
+    }
+
+
+
+    /**
+     * 댓글 삭제 (댓글과 대댓글 모두 포함)
+     */
+    @DeleteMapping("/{commentNo}")
+    public ApiResponse deleteComment(@PathVariable Long postNo, @PathVariable Long commentNo) {
+        String resultcode = SuccessStatus._OK.getCode();
+        String resultmsg = SuccessStatus._OK.getMessage();
+
+        return new ApiResponse<>(true, resultcode, resultmsg);
+    }
+
+
+}

--- a/src/main/java/com/backend/farmon/dto/Board/BoardRequestDto.java
+++ b/src/main/java/com/backend/farmon/dto/Board/BoardRequestDto.java
@@ -1,0 +1,108 @@
+package com.backend.farmon.dto.Board;
+
+import com.backend.farmon.dto.PostType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class BoardRequestDto {
+
+    // BasePost는 모든 게시글의 공통적인 속성을 담는 추상 클래스입니다.
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "모든 게시글에 공통된 속성을 가진 기본 게시글 클래스입니다.")
+    public static abstract class BasePost {
+        @Schema(description = "게시글 제목", example = "게시글 제목 예시")
+        private String postTitle;   // 게시글 제목
+
+        @Schema(description = "게시글 내용", example = "게시글 내용 예시")
+        private String postContent; // 게시글 내용
+
+        @Schema(description = "작성자 ID (userNo)", example = "12345")
+        private Long userNo;        // 작성자 ID (userNo)
+
+        @Schema(description = "게시판 ID (boardNo)", example = "67890")
+        private Long boardNo;       // 게시판 ID (boardNo)
+
+        @Schema(description = "게시글에 대한 좋아요 수", example = "10")
+        private int like;           // 좋아요 수
+
+        @Schema(description = "게시글에 대한 댓글 수", example = "5")
+        private int comment;        // 댓글 수
+
+        @Schema(description = "게시글 종류 (예: QnA, 일반 게시글 등)", example = "QnA")
+        public PostType postType;   // 게시글 종류 (예: QnA, 일반 게시글 등)
+    }
+
+    // AllPost는 모든 종류의 게시글을 위한 클래스입니다. (BasePost를 확장)
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "전체게시판에 있는 글")
+    public static class AllPost extends BasePost {
+        // AllPost에는 추가적인 필드나 메서드가 필요할 경우 이곳에 작성
+    }
+
+    // PopularPost는 인기 게시글을 위한 클래스입니다. (BasePost를 확장)
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "인기 게시글")
+    public static class PopularPost extends BasePost {
+        // PopularPost에는 추가적인 필드나 메서드가 필요할 경우 이곳에 작성
+    }
+
+    // QnaPost는 QnA 게시판의 게시글을 위한 클래스입니다. (BasePost를 확장)
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "QnA 게시판에 관련된 게시글 ")
+    public static class QnaPost extends BasePost {
+
+        @Schema(description = "답변 여부 (QnA 게시판에서만 사용)", example = "true")
+        private boolean isAnswered;  // 답변 여부 (QnA 게시판에서만 사용)
+
+        // QnA 게시판에서만 답변 여부를 설정하도록 하는 메서드
+        @Schema(description = "QnA 게시판에서만 답변 여부를 설정하는 메서드입니다.")
+        public void setAnsweredForQnA(boolean answered) {
+            if (this.postType == PostType.QnA) {
+                this.isAnswered = answered;
+            }
+        }
+
+        @Schema(description = "답변 여부를 반환하는 메서드입니다.", example = "true")
+        private boolean getIsAnswered() {
+            return isAnswered;
+        }
+    }
+
+    // ExpertLounge는 전문가 라운지 게시글을 위한 클래스입니다. (BasePost를 확장)
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "전문가 라운지 게시글")
+    public static class ExpertLounge extends BasePost {
+
+        @Schema(description = "지역 ID", example = "123")
+        private Long areaId; // 지역 ID
+
+        @Schema(description = "위치 ID", example = "456")
+        private Long locationId; // 위치 ID
+    }
+
+    // ExpertColumn은 전문가 칼럼 게시글을 위한 클래스입니다. (BasePost를 확장)
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "전문가 칼럼 게시글")
+    public static class ExpertColumn extends BasePost {
+
+        @Schema(description = "전체 칼럼 수", example = "10")
+        private Long All;  // 전체 칼럼 수
+
+        @Schema(description = "노하우 칼럼 수", example = "5")
+        private Long knowHow;  // 노하우 칼럼 수
+    }
+}

--- a/src/main/java/com/backend/farmon/dto/Comment/CommenResponseDTO.java
+++ b/src/main/java/com/backend/farmon/dto/Comment/CommenResponseDTO.java
@@ -1,0 +1,88 @@
+package com.backend.farmon.dto.Comment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+
+public class CommenResponseDTO {
+
+
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    @NoArgsConstructor
+    @Schema(description = "부모 댓글 조회 DTO")
+    public class CommentParentReadResponseDto {
+
+        @Schema(description = "댓글 ID", example = "1", required = true)
+        private Long id;
+
+        //이 부분 entity에 생각좀 해봐야함
+        @Schema(description = "작성자 이름", example = "JohnDoe", required = true)
+        private String name;
+
+        @Schema(description = "댓글 내용", example = "이것은 댓글입니다.", required = true)
+        private String commentContent;
+
+        @Schema(description = "수정된 시간", example = "2025-01-12T14:30:00", required = true)
+        private String modifiedTime;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    @NoArgsConstructor
+    @Schema(description = "대댓글 조회 DTO")
+    public class CommentChildReadResponseDto {
+
+        @Schema(description = "댓글 ID", example = "1", required = true)
+        private Long id;
+
+        //이 부분 entity에 생각좀 해봐야함
+        @Schema(description = "작성자 이름", example = "JohnDoe", required = true)
+        private String name;
+
+        @Schema(description = "댓글 내용", example = "이것은 댓글입니다.", required = true)
+        private String commentContent;
+
+        @Schema(description = "수정된 시간", example = "2025-01-12T14:30:00", required = true)
+        private String modifiedTime;
+    }
+
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    @NoArgsConstructor
+    @Schema(description = "부모댓글 + 대댓글 조회 DTO")
+    public class CommentAllByPostResponseDto {
+
+        @Schema(description = "댓글 ID", example = "1", required = true)
+        private Long id;
+
+        @Schema(description = "작성자 이름", example = "페이커", required = true)
+        private String name;
+
+        @Schema(description = "댓글 내용", example = "이것은 댓글입니다.", required = true)
+        private String commentContent;
+
+        @Schema(description = "수정된 시간", example = "2025-01-12 15:45:00", required = true)
+        private String modifiedTime;
+
+        @Schema(description = "대댓글 리스트", example = "[]")
+        private List<CommentAllByPostResponseDto> childComments;
+    }
+
+
+
+    }
+
+
+
+

--- a/src/main/java/com/backend/farmon/dto/Comment/CommentRequestDTO.java
+++ b/src/main/java/com/backend/farmon/dto/Comment/CommentRequestDTO.java
@@ -1,0 +1,110 @@
+package com.backend.farmon.dto.Comment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+public class CommentRequestDTO {
+
+
+
+
+//-------------댓글 -----------------
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "부모 댓글 저장 DTO")
+    public class CommentSaveRequestDto {
+
+        @Schema(description = "댓글 내용", example = "이것은 댓글입니다.", required = true)
+        private String commentContent;
+
+        @Schema(description = "작성자 유저 번호", example = "1", required = true)
+        private Long userNo;
+
+        @Schema(description = "게시글 번호", example = "10", required = true)
+        private Long postNo;
+
+
+    }
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "대댓글 조회 DTO")
+    public class CommentParenReadtDTO {
+
+        @Schema(name="대댓글을 특정 조회순으로 가져옴")
+        private String sort;
+
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "부모 댓글 조회 DTO")
+    public class CommentChilldtDTO {
+
+        @Schema(name="부모 댓글을 특정 조회순으로 가져옴")
+        private String sort;
+
+    }
+
+    @ToString
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "대댓글 저장 DTO")
+    public class CommentSaveChildRequestDto {
+
+        @Schema(description = "대댓글 저장 내용", required = true, example = "This is a child comment")
+        private String commentContent;
+
+        @Schema(description = "댓글을 저장하는 회원 번호", example = "1234")
+        private Long userNo;
+
+        @Schema(description = "댓글 깊이", example = "2")
+        private int depth;
+    }
+
+
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "댓글  수정 DTO")
+    public class CommentUpdateRequestDto {
+
+        @Schema(description = "업데이트할 댓글 내용", example = "수정된 댓글 내용입니다.")
+        private String commentContent;
+
+      //시간 추가?
+
+    }
+
+
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "댓글 페이징 요청 DTO")
+    public class CommentPagingRequestDto {
+
+        @Schema(description = "댓글 내용", example = "이것은 댓글입니다.", required = true)
+        private String commentContent;
+
+        @Schema(description = "작성자 유저 번호", example = "1", required = true)
+        private Long userNo;
+
+        @Schema(description = "게시글 번호", example = "10", required = true)
+        private Long postNo;
+    }
+
+
+}

--- a/src/main/java/com/backend/farmon/dto/PostType.java
+++ b/src/main/java/com/backend/farmon/dto/PostType.java
@@ -1,0 +1,13 @@
+package com.backend.farmon.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "게시판 타입")
+public enum PostType {
+    ALL, POPULAR, QnA, EXPERT_LOUNGE, EXPERT_COLUMN;
+
+    // QnA 게시판만 답변 유무를 체크하도록 하는 메서드
+    public boolean isAnswerRequired() {
+        return this == QnA;  // QnA일 경우에만 true 반환
+    }
+}

--- a/src/main/java/com/backend/farmon/service/BoardService.java
+++ b/src/main/java/com/backend/farmon/service/BoardService.java
@@ -1,0 +1,4 @@
+package com.backend.farmon.service;
+
+public class BoardService {
+}

--- a/src/main/java/com/backend/farmon/service/S3ImgService.java
+++ b/src/main/java/com/backend/farmon/service/S3ImgService.java
@@ -1,0 +1,12 @@
+package com.backend.farmon.service;
+
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Service
+
+public class S3ImgService {
+
+
+}


### PR DESCRIPTION
#️⃣연관된 이슈
---

댓글과 대댓글에 대한 API작성

 📝작업 내용
---
개인적으로 이부분이 설계하는데에 어려움이 많은데 
일단 부모댓글 조회,대댓글 조회, 전체(부모+대댓글 ) 조회 이 부분이 확신이 안 섭니다. (CommentRequestDTO)
사실 수정은 단순 내용 수정으로 했고  
api 설계시 특정게시글 번호 (postNo ) 에 따라 저장이 되고 
대댓글인 경우 parentNo  (부모댓글)에 맞게 설정하도록 했습니다.
APi response 추가했는데 반영이 안된 거 같습니다 .

Long userId는 일단 모두 포함인데 이 부분을 나중에 로그인 하고 하면 수정해야 할꺼 같습니다.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
CommentRequestDTO,CommentResponseDTO 

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>대댓글과 댓글에 대한 api 설계 부분 조금만 봐 주시면 감사하겠습니다. 
