### PR TITLE
✨ [Feat] 유저/전문가 관련 엔티티 클래스 추가

### DIFF
--- a/src/main/java/com/backend/farmon/FarmonApplication.java
+++ b/src/main/java/com/backend/farmon/FarmonApplication.java
@@ -2,7 +2,9 @@ package com.backend.farmon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class FarmonApplication {
 

--- a/src/main/java/com/backend/farmon/domain/Area.java
+++ b/src/main/java/com/backend/farmon/domain/Area.java
@@ -1,0 +1,33 @@
+package com.backend.farmon.domain;
+
+import com.backend.farmon.domain.commons.BaseEntity;
+import com.backend.farmon.domain.mapping.ExpertArea;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@DynamicUpdate
+@DynamicInsert
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Area extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10)
+    private String areaName;  // 서비스 지역 이름  ex)서울, 강동구
+
+    @Column(nullable = false, length = 10)
+    private String areaNameDetail ; // 서비스 지역 디테일  ex)감남구, 강동구
+
+    @OneToMany(mappedBy = "area", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExpertArea> expertAreaList = new ArrayList<>();
+}

--- a/src/main/java/com/backend/farmon/domain/Expert.java
+++ b/src/main/java/com/backend/farmon/domain/Expert.java
@@ -1,0 +1,53 @@
+package com.backend.farmon.domain;
+
+import com.backend.farmon.domain.commons.BaseEntity;
+import com.backend.farmon.domain.enums.Gender;
+import com.backend.farmon.domain.enums.MemberStatus;
+import com.backend.farmon.domain.enums.Role;
+import com.backend.farmon.domain.mapping.ExpertArea;
+import com.backend.farmon.domain.mapping.ExpertCrops;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@DynamicUpdate
+@DynamicInsert
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Expert extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+//    @Column(nullable = false) 와이어프레임 나오면 결정예정
+    private String expertDescription; // 전문가 한줄소개
+
+//    @Column(nullable = false) 와이어프레임 나오면 결정예정
+    private Integer career;
+
+//    @Column(nullable = false) 와이어프레임 나오면 결정예정
+    private Integer availableRage;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;  // user와 1:1관계
+
+    @OneToMany(mappedBy = "expert", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExpertCrops> expertCropsList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "expert", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExpertArea> expertAreaList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "expert", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Portfolio> portfolioList = new ArrayList<>();
+}

--- a/src/main/java/com/backend/farmon/domain/Portfolio.java
+++ b/src/main/java/com/backend/farmon/domain/Portfolio.java
@@ -1,0 +1,39 @@
+package com.backend.farmon.domain;
+
+import com.backend.farmon.domain.commons.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@DynamicUpdate
+@DynamicInsert
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Portfolio extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String thumbnailImg;
+
+    // 나중에 카테고리 테이블이랑 매핑하는 방식으로 수정될 수도 있음
+    @Column(nullable = false)
+    private String serviceCategory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "expert_id")
+    private Expert expert;
+
+    @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PortfolioImg> portfolioImgList = new ArrayList<>();
+}

--- a/src/main/java/com/backend/farmon/domain/PortfolioImg.java
+++ b/src/main/java/com/backend/farmon/domain/PortfolioImg.java
@@ -1,0 +1,30 @@
+package com.backend.farmon.domain;
+
+import com.backend.farmon.domain.commons.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@DynamicUpdate
+@DynamicInsert
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PortfolioImg extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "portfolio_id")
+    private Portfolio portfolio;
+}

--- a/src/main/java/com/backend/farmon/domain/User.java
+++ b/src/main/java/com/backend/farmon/domain/User.java
@@ -1,0 +1,88 @@
+package com.backend.farmon.domain;
+
+
+import com.backend.farmon.domain.commons.BaseEntity;
+import com.backend.farmon.domain.enums.Gender;
+import com.backend.farmon.domain.enums.MemberStatus;
+import com.backend.farmon.domain.enums.Role;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@DynamicUpdate
+@DynamicInsert
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class User extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10)
+    private String userName;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, unique = true) // 이메일주소 중복 불가
+    private String email;
+
+    @Column(nullable = false, length = 10)
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate birthDate;
+
+    @Column(nullable = false, length = 20)
+    private String phoneNum;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(15)")
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(15) DEFAULT 'FARMER'")
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, columnDefinition = "VARCHAR(15) DEFAULT 'ACTIVE'")
+    private MemberStatus status;
+
+    private String profileImageUrl;
+
+    private String chatAverageResponseTime; // 채팅 평균 응답 시간
+
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    private Boolean isPhoneVerified; // 휴대폰 본인인증 여부
+
+    private LocalDate inactiveDate;  // 탈퇴일
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Expert expert; // 전문가와 1:1관계
+
+//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<CharRoom> charRoomList = new ArrayList<>(); // 채팅방 양방향 매핑
+//
+//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Estimate> estimateList = new ArrayList<>();  // 견적 양방향 매핑
+//
+//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Post> postList = new ArrayList<>();  // 게시글 양방향 매핑
+//
+//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Like> likeList = new ArrayList<>();  // 좋아요 양방향 매핑
+//
+//    public void encodePassword(String password) {
+//        this.password = password;
+//    }
+}

--- a/src/main/java/com/backend/farmon/domain/commons/BaseEntity.java
+++ b/src/main/java/com/backend/farmon/domain/commons/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.backend.farmon.domain.commons;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/backend/farmon/domain/enums/Gender.java
+++ b/src/main/java/com/backend/farmon/domain/enums/Gender.java
@@ -1,0 +1,5 @@
+package com.backend.farmon.domain.enums;
+
+public enum Gender {
+    MALE, FEMALE, NONE
+}

--- a/src/main/java/com/backend/farmon/domain/enums/MemberStatus.java
+++ b/src/main/java/com/backend/farmon/domain/enums/MemberStatus.java
@@ -1,0 +1,5 @@
+package com.backend.farmon.domain.enums;
+
+public enum MemberStatus {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/com/backend/farmon/domain/enums/Role.java
+++ b/src/main/java/com/backend/farmon/domain/enums/Role.java
@@ -1,0 +1,5 @@
+package com.backend.farmon.domain.enums;
+
+public enum Role {
+    ADMIN, FARMER, EXPERT
+}

--- a/src/main/java/com/backend/farmon/domain/mapping/ExpertArea.java
+++ b/src/main/java/com/backend/farmon/domain/mapping/ExpertArea.java
@@ -1,0 +1,27 @@
+package com.backend.farmon.domain.mapping;
+
+import com.backend.farmon.domain.Area;
+import com.backend.farmon.domain.Crop;
+import com.backend.farmon.domain.Expert;
+import com.backend.farmon.domain.commons.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ExpertArea extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "expert_id")
+    private Expert Expert;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "area_id")
+    private Area area;
+}

--- a/src/main/java/com/backend/farmon/domain/mapping/ExpertCrops.java
+++ b/src/main/java/com/backend/farmon/domain/mapping/ExpertCrops.java
@@ -1,0 +1,26 @@
+package com.backend.farmon.domain.mapping;
+
+import com.backend.farmon.domain.Crop;
+import com.backend.farmon.domain.Expert;
+import com.backend.farmon.domain.commons.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ExpertCrops extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "expert_id")
+    private Expert Expert;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "crop_id")
+//    private Crop crop;  // 작물 양방향 매핑
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #35 

## 📝작업 내용

유저/전문가 관련 엔티티 클래스 작성하였습니다.
작성한 엔티티 클래스
>- 유저 엔티티 클래스 추가
>- 전문가 엔티티 클래스 추가
>- 전문가 포트폴리오 엔티티 클래스 추가
>- 전문가 포트폴리오 상세 이미지 엔티티 클래스 추가
>- 서비스 지역 엔티티 클래스 추가
>- 전문가 - 서비스 지역 매핑 엔티티 클래스 추가
>- 전문가 - 작물 매핑 엔티티 클래스 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 와이어프레임에 따라 수정이 될 수도 있는 부분들은 주석으로 달아놓았습니다.
erdCloud에서 전문가-서비스 지역 엔티티에 활동 가능 범위 속성은 전문가 엔티티의 활동 가능 범위 속성과 겹쳐 제외하였습니다.