### PR TITLE
✨ [Feat] 채팅 관련 엔티티 클래스 추가

### DIFF
--- a/src/main/java/com/backend/farmon/FarmonApplication.java
+++ b/src/main/java/com/backend/farmon/FarmonApplication.java
@@ -2,7 +2,9 @@ package com.backend.farmon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class FarmonApplication {
 

--- a/src/main/java/com/backend/farmon/controller/ChatMessageController.java
+++ b/src/main/java/com/backend/farmon/controller/ChatMessageController.java
@@ -15,7 +15,7 @@ public class ChatMessageController {
 
     // 채팅 메시지 보내기
     // /send/chat/message/{chatRoomId}
-    @MessageMapping(value="/chat/message/{{chatRoomId}")
+    @MessageMapping(value="/chat/message/{chatRoomId}")
     public void sendChatMessage (@DestinationVariable("chatRoomId") Long chatRoomId,
                                  ChatRequest.ChatMessageDTO dto) {
         log.info("전송할 메시지 내용: {}", dto);
@@ -24,6 +24,6 @@ public class ChatMessageController {
 
         // 구독자들에게 메시지 전달
         // /receive/chat/message/{chatRoomId}
-//        simpMessagingTemplate.convertAndSend("/sub/api/chat/message/"+chatRoomId, dto);
+//        simpMessagingTemplate.convertAndSend("/receive/chat/message/"+chatRoomId, dto);
     }
 }

--- a/src/main/java/com/backend/farmon/domain/ChatMessage.java
+++ b/src/main/java/com/backend/farmon/domain/ChatMessage.java
@@ -1,0 +1,35 @@
+package com.backend.farmon.domain;
+
+import com.backend.farmon.domain.commons.BaseEntity;
+import com.backend.farmon.domain.enums.ChatMessageType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Entity
+public class ChatMessage extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // pk
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChatMessageType type; // 메시지 타입
+
+    @Column(nullable = false)
+    private String content; // 메시지 내용
+
+    @Column(columnDefinition = "TINYINT(1) DEFAULT 0", nullable = false)
+    private Boolean isRead; // 메시지 읽음 여부
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom; // 채팅방과 다대일 양방향
+}

--- a/src/main/java/com/backend/farmon/domain/ChatRoom.java
+++ b/src/main/java/com/backend/farmon/domain/ChatRoom.java
@@ -1,0 +1,50 @@
+package com.backend.farmon.domain;
+
+import com.backend.farmon.domain.commons.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+@Entity
+public class ChatRoom extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // pk
+
+    @Column(columnDefinition = "TINYINT(1) DEFAULT 0", nullable = false)
+    private Boolean isFarmerComplete; // 농업인 거래 여부
+
+    @Column(columnDefinition = "TINYINT(1) DEFAULT 0", nullable = false)
+    private Boolean isExpertComplete; // 전문가 거래 여부
+
+    private LocalDateTime farmerLastEnter; // 농업인 마지막 접속 시간
+
+    private LocalDateTime expertLastEnter; // 전문가 마지막 접속 시간
+
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List <ChatMessage> messages = new ArrayList<>(); // 채팅 메시지와 일대다 양방향
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "farmer_id", nullable = false)
+//    private User farmer; // 농업인과 다대일
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "expert_id", nullable = false)
+//    private Expert expert; // 전문가와 다대일
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "estimate_id", nullable = false)
+//    private Estimate estimate; // 견적과 다대일
+
+}

--- a/src/main/java/com/backend/farmon/domain/ChatRoom.java
+++ b/src/main/java/com/backend/farmon/domain/ChatRoom.java
@@ -33,7 +33,7 @@ public class ChatRoom extends BaseEntity {
     private LocalDateTime expertLastEnter; // 전문가 마지막 접속 시간
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List <ChatMessage> messages = new ArrayList<>(); // 채팅 메시지와 일대다 양방향
+    private List <ChatMessage> messageList = new ArrayList<>(); // 채팅 메시지와 일대다 양방향
 
 //    @ManyToOne(fetch = FetchType.LAZY)
 //    @JoinColumn(name = "farmer_id", nullable = false)

--- a/src/main/java/com/backend/farmon/domain/commons/BaseEntity.java
+++ b/src/main/java/com/backend/farmon/domain/commons/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.backend.farmon.domain.commons;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name="created_at",nullable = false,columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name="updated_at",nullable = false,columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/backend/farmon/domain/enums/ChatMessageType.java
+++ b/src/main/java/com/backend/farmon/domain/enums/ChatMessageType.java
@@ -1,0 +1,7 @@
+package com.backend.farmon.domain.enums;
+
+// 채팅 메시지 타입
+public enum ChatMessageType {
+    // 텍스트, 이미지, 거래 완료, 퇴장
+    TEXT, IMAGE, COMPLETE, EXIT
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #33 

## 📝작업 내용
채팅과 관련한 엔티티 클래스들을 추가했습니다. 
채팅메시지-채팅방은 N:1 양방향 관계로 두었고, 채팅방과 연관된 유저(농업인), 전문가, 견적 매핑 부분은 주석으로 처리해 놓았습니다. 채팅 메시지 type은 enum 클래스로 두었습니다.

## 💬리뷰 요구사항(선택)

현재 ERD에서는 채팅방 테이블의 전문가 아이디(expert_id)가 User와 매핑되도록 설계되어 있습니다. 이와 관련하여 전문가 아이디를 User와 직접 연관시키는 것이 적절할지, Expert와 연관시키는 것이 더 적합할지 고민 중입니다.