### PR TITLE
✨♻️[Feat, Refactor] 채팅 관련 엔티티 연결, 채팅&홈&농업인-전문가 전환 API 명세서 리팩토링

### DIFF
--- a/src/main/java/com/backend/farmon/apiPayload/ApiResponse.java
+++ b/src/main/java/com/backend/farmon/apiPayload/ApiResponse.java
@@ -5,6 +5,7 @@ import com.backend.farmon.apiPayload.code.status.SuccessStatus;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -14,12 +15,18 @@ import lombok.Getter;
 public class ApiResponse<T> {
 
     @JsonProperty("isSuccess")
+    @Schema(description = "요청 성공 여부")
     private final Boolean isSuccess; // 성공여부
-    private final String code; // 세부적인 응답 사항 (코드)
-    private final String message;
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private T result; // 데이터
 
+    @Schema(description = "상태 코드")
+    private final String code; // 세부적인 응답 사항 (코드)
+
+    @Schema(description = "상세 메시지")
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "반환 데이터")
+    private T result; // 데이터
 
     // 성공한 경우 응답 생성
     public static <T> ApiResponse<T> onSuccess(T result){

--- a/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
@@ -16,9 +16,18 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-    // 멤버 관려 에러
-    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "아이디와 일치하는 사용자가 없습니다."),
-    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
+    // 유저 관려 에러
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "아이디와 일치하는 사용자가 없습니다."),
+    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "닉네임은 필수 입니다."),
+
+    // 전문가 관련 에러
+    EXPERT_NOT_FOUND(HttpStatus.BAD_REQUEST, "EXPERT4001", "아이디와 일치하는 전문가가 없습니다."),
+
+    // 견적 관련 에러
+    ESTIMATE_NOT_FOUND(HttpStatus.BAD_REQUEST, "ESTIMATE4001", "견적 아이디와 일치하는 견적이 없습니다."),
+
+    // 채팅방 관련 에러
+    CHATROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHATROOM4001", "채팅방 아이디와 일치하는 채팅방이 없습니다."),
 
     // 페이지 번호
     PAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "PAGE4001", "페이지 번호는 1 이상이어야 합니다.");

--- a/src/main/java/com/backend/farmon/controller/ChatRoomController.java
+++ b/src/main/java/com/backend/farmon/controller/ChatRoomController.java
@@ -5,6 +5,8 @@ import com.backend.farmon.dto.chat.ChatResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +27,10 @@ public class ChatRoomController {
                     "유저 아이디, 읽음 여부 필터, 페이지 번호를 쿼리 스트링으로 입력해주세요."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAGE4001", description = "페이지 번호는 1 이상이어야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
@@ -49,7 +54,10 @@ public class ChatRoomController {
                     "유저 아이디, 읽음 여부 필터, 검색할 채팅 상대 이름, 페이지 번호를 쿼리 스트링으로 입력해주세요."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAGE4001", description = "페이지 번호는 1 이상이어야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
@@ -75,7 +83,10 @@ public class ChatRoomController {
                     "유저 아이디, 읽음 여부 필터, 검색할 전문가의 작물 이름, 페이지 번호를 쿼리 스트링으로 입력해주세요."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAGE4001", description = "페이지 번호는 1 이상이어야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
@@ -94,6 +105,31 @@ public class ChatRoomController {
     }
 
 
+    // 전문가가 농업인의 견적을 보고 채팅 신청 (채팅방 생성)
+    @Operation(
+            summary = "전문가가 농업인의 견적을 보고 채팅을 신청하여 채팅방을 생성",
+            description = "전문가가 농업인의 견적을 보고 채팅을 신청하여 채팅방을 생성하는 API 입니다. " +
+                    "유저 아이디, 견적 아이디를 쿼리 스트링으로 입력해주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "EXPERT4001", description = "아이디와 일치하는 전문가가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ESTIMATE4001", description = "견적 아이디와 일치하는 견적이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저(전문가)의 아이디(pk)", example = "1", required = true),
+            @Parameter(name = "estimateId", description = "채팅하려는 견적의 아이디", example = "1", required = true),
+    })
+    @PostMapping("/room")
+    public ApiResponse<ChatResponse.ChatRoomCreateDTO> postChatRoom (@RequestParam(name = "userId") Long userId,
+                                                                     @RequestParam(name = "estimateId") Long estimateId) {
+        ChatResponse.ChatRoomCreateDTO response = ChatResponse.ChatRoomCreateDTO.builder().build();
+
+        return ApiResponse.onSuccess(response);
+    }
+
+
     // 채팅방 입장
     @Operation(
             summary = "채팅방 아이디이와 일치하는 채팅방 입장",
@@ -101,7 +137,10 @@ public class ChatRoomController {
                     "유저 아이디, 채팅방 아이디를 쿼리 스트링으로 입력해주세요."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHATROOM4001", description = "채팅방 아이디와 일치하는 채팅방이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
@@ -123,7 +162,10 @@ public class ChatRoomController {
                     "유저 아이디, 채팅방 아이디를 쿼리 스트링으로 입력해주세요."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHATROOM4001", description = "채팅방 아이디와 일치하는 채팅방이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -5,6 +5,8 @@ import com.backend.farmon.dto.home.HomeResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -18,23 +20,89 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/home")
 public class HomeController {
 
-    // 홈 화면 조회
+    // 홈 화면 - 커뮤니티 게시글 조회
     @Operation(
-            summary = "홈 화면 조회 API",
-            description = "홈 화면 로딩에 필요한 정보를 조회합니다. 로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
+            summary = "홈 화면 커뮤니티 게시글 조회 API",
+            description = "홈 화면에서 커뮤니티 카테고리에 따른 게시글을 조회합니다. " +
+                    "필터링 할 커뮤니티 카테고리 이름을 쿼리 스트링으로 입력해 주세요. " +
+                    "로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1"),
             @Parameter(name = "category", description = "커뮤니티 카테고리 이름", example = "인기", required = true)
     })
-    @GetMapping("")
-    public ApiResponse<HomeResponse.HomePageDTO> getChatRoomPage (@RequestParam(name = "userId", required = false) Long userId,
-                                                                  @RequestParam(name = "category") String category){
-        return null;
+    @GetMapping("/community")
+    public ApiResponse<HomeResponse.PostListDTO> getHomePosts (@RequestParam(name = "userId", required = false) Long userId,
+                                                               @RequestParam(name = "category") String category){
+        HomeResponse.PostListDTO response = HomeResponse.PostListDTO.builder().build();;
+        return ApiResponse.onSuccess(response);
     }
+
+
+    // 홈 화면 - 인기 칼럼 조회
+    @Operation(
+            summary = "홈 화면 인기 칼럼 조회 API",
+            description = "홈 화면에서 인기 칼럼 게시글 목록을 조회합니다. 로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1"),
+    })
+    @GetMapping("/popular")
+    public ApiResponse<HomeResponse.PopularPostListDTO> getPopularPosts (@RequestParam(name = "userId", required = false) Long userId){
+        HomeResponse.PopularPostListDTO response = HomeResponse.PopularPostListDTO.builder().build();;
+        return ApiResponse.onSuccess(response);
+    }
+
+
+    // 최근 검색어 조회
+    @Operation(
+            summary = "홈 화면 최근 검색어 조회 API",
+            description = "홈 화면 검색 창에서 사용자의 최근 검색어들을 조회합니다. 로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1")
+    })
+    @GetMapping("/search/recent")
+    public ApiResponse<HomeResponse.RecentSearchListDTO> getRecentSearches (@RequestParam(name = "userId", required = false) Long userId){
+        HomeResponse.RecentSearchListDTO response = HomeResponse.RecentSearchListDTO.builder().build();;
+        return ApiResponse.onSuccess(response);
+    }
+
+
+    // 추천 검색어 조회
+    @Operation(
+            summary = "홈 화면 추천 검색어 조회 API",
+            description = "홈 화면 검색 창에서 추천 검색어들을 조회합니다.  로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1")
+    })
+    @GetMapping("/search/recommend")
+    public ApiResponse<HomeResponse.RecommendSearchListDTO> getRecommendSearches (@RequestParam(name = "userId", required = false) Long userId){
+        HomeResponse.RecommendSearchListDTO response = HomeResponse.RecommendSearchListDTO.builder().build();;
+        return ApiResponse.onSuccess(response);
+    }
+
 
     // 특정 검색어 삭제 API
     @Operation(
@@ -42,17 +110,21 @@ public class HomeController {
             description = "홈 화면에서 특정 검색어를 삭제하는 API 입니다. 유저 아이디와 삭제할 검색어 이름을 쿼리 스트링으로 입력해 주세요."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
             @Parameter(name = "name", description = "삭제 할 검색어 이름", example = "병충해 관리")
     })
     @DeleteMapping("/search")
-    public ApiResponse<HomeResponse.HomePageDTO> deleteSearchName(@RequestParam(name = "userId") Long userId,
+    public ApiResponse<HomeResponse.SearchDeleteDTO> deleteSearchName(@RequestParam(name = "userId") Long userId,
                                                                   @RequestParam(name = "name") String searchName){
-        return null;
+        HomeResponse.SearchDeleteDTO response = HomeResponse.SearchDeleteDTO.builder().build();;
+        return ApiResponse.onSuccess(response);
     }
+
 
     // 검색어 전체 삭제 API
     @Operation(
@@ -60,13 +132,34 @@ public class HomeController {
             description = "홈 화면에서 사용자의 검색어를 전체 삭제 API. 유저 아이디를 쿼리 스트링으로 입력해 주세요."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1")
     })
     @DeleteMapping("/search/all")
-    public ApiResponse<HomeResponse.HomePageDTO> deleteAllSearchName(@RequestParam(name = "userId") Long userId) {
-        return null;
+    public ApiResponse<HomeResponse.SearchDeleteDTO> deleteAllSearchName(@RequestParam(name = "userId") Long userId) {
+        HomeResponse.SearchDeleteDTO response = HomeResponse.SearchDeleteDTO.builder().build();;
+        return ApiResponse.onSuccess(response);
     }
+
+    // 홈 화면 검색 - 자동 완성
+//    @Operation(
+//            summary = "홈 화면 조회 API",
+//            description = "홈 화면 로딩에 필요한 정보를 조회합니다. 로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
+//    )
+//    @ApiResponses({
+//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+//    })
+//    @Parameters({
+//            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1"),
+//    })
+//    @GetMapping("/search")
+//    public ApiResponse<HomeResponse.HomePageDTO> getChatRoomPage (@RequestParam(name = "userId", required = false) Long userId,
+//                                                                  @RequestParam(name = "category") String category){
+//        HomeResponse.HomePageDTO response = HomeResponse.HomePageDTO.builder().build();;
+//        return ApiResponse.onSuccess(response);
+//    }
 }

--- a/src/main/java/com/backend/farmon/controller/UserController.java
+++ b/src/main/java/com/backend/farmon/controller/UserController.java
@@ -7,6 +7,8 @@ import com.backend.farmon.dto.user.MypageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -48,7 +50,9 @@ public class UserController {
                     "유저 아이디, 사용자 유형을 쿼리 스트링으로 입력해주세요."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
@@ -56,6 +60,8 @@ public class UserController {
     })
     public ApiResponse<ExchangeResponse> patchUserRole(@RequestParam(name="userId") Long userId,
                                                        @RequestParam(name="type") String type) {
-        return null;
+        ExchangeResponse response = ExchangeResponse.builder().isExchange(true).build();
+
+        return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/backend/farmon/domain/ChatRoom.java
+++ b/src/main/java/com/backend/farmon/domain/ChatRoom.java
@@ -35,16 +35,16 @@ public class ChatRoom extends BaseEntity {
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List <ChatMessage> messageList = new ArrayList<>(); // 채팅 메시지와 일대다 양방향
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "farmer_id", nullable = false)
-//    private User farmer; // 농업인과 다대일
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "farmer_id", nullable = false)
+    private User farmer; // 농업인과 다대일
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "expert_id", nullable = false)
-//    private Expert expert; // 전문가와 다대일
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "expert_id", nullable = false)
+    private Expert expert; // 전문가와 다대일
 
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "estimate_id", nullable = false)
-//    private Estimate estimate; // 견적과 다대일
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "estimate_id", nullable = false)
+    private Estimate estimate; // 견적과 다대일
 
 }

--- a/src/main/java/com/backend/farmon/dto/chat/ChatResponse.java
+++ b/src/main/java/com/backend/farmon/dto/chat/ChatResponse.java
@@ -118,6 +118,33 @@ public class ChatResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    @Schema(description = "채팅방 생성 시(전문가가 농업인이 올린 견적을 보고 채팅 신청 시) 응답 정보")
+    public static class ChatRoomCreateDTO {
+        @Schema(description = "생성된 채팅방 아이디", example = "1")
+        Long chatRoomId;
+
+        @Schema(description = "채팅 중인 상대방 이름", example = "김팜온")
+        String name;
+
+        @Schema(description = "채팅 중인 상대방 프로필 이미지")
+        String profileImage;
+
+        @Schema(description = "채팅 상대 역할, 농업인 또는 전문가", example = "농업인")
+        String type;
+
+        @Schema(description = "채팅 상대의 마지막 채팅방 접속 시간", example = "28분")
+        String lastEnterTime;
+
+        @Schema(description = "채팅 상대의 평균 메시지 응답 시간", example = "1시간")
+        String averageResponseTime;
+    }
+
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
     @Schema(description = "채팅방 삭제 응답 정보")
     public static class ChatRoomDeleteDTO {
         @Schema(description = "삭제 여부 / 삭제에 성공했다면 true, 실패했다면 false", example = "true")

--- a/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
+++ b/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
@@ -12,26 +12,10 @@ public class HomeResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    @Schema(description = "홈 페이지 조회 정보")
-    public static class HomePageDTO {
-
-        @Schema(description = "로그인한 사용자의 이름, 로그인 하지 않은 사용자일 경우 null", example = "김팜온")
-        String name;
-
-        @Schema(description = "로그인한 사용자의 유형(농업인 or 전문가), 로그인 하지 않은 사용자일 경우 null", example = "농업인")
-        String type;
-
+    @Schema(description = "홈 페이지 게시글 리스트 정보")
+    public static class PostListDTO {
         @Schema(description = "커뮤니티 카테고리에 따른 게시글 리스트")
         List <PostDetailDTO> postList;
-
-        @Schema(description = "인기 칼럼 리스트")
-        List <PopularPostDetailDTO> popularPostList;
-
-        @Schema(description = "최근 검색어 리스트")
-        List <String> recentSearchList;
-
-        @Schema(description = "추천 검색어 리스트")
-        List <String> recommendSearchList;
     }
 
     @Getter
@@ -39,10 +23,10 @@ public class HomeResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    @Schema(description = "홈 페이지 커뮤니티 게시글 정보")
+    @Schema(description = "홈 페이지 커뮤니티 게시글 상세 정보")
     public static class PostDetailDTO {
         
-        @Schema(description = "커뮤니티 게시글 아이디")
+        @Schema(description = "커뮤니티 게시글 아이디", example = "1")
         Long postId;
 
         @Schema(description = "커뮤니티 게시글 제목")
@@ -58,6 +42,18 @@ public class HomeResponse {
         Integer commentCount;
     }
 
+    @ToString
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "홈 페이지 인기 칼럼 리스트 정보")
+    public static class PopularPostListDTO {
+        @Schema(description = "인기 칼럼 리스트")
+        List <PopularPostDetailDTO> popularPostList;
+    }
+
     @Getter
     @Setter
     @NoArgsConstructor
@@ -66,7 +62,7 @@ public class HomeResponse {
     @Schema(description = "홈 페이지 인기 칼럼 정보")
     public static class PopularPostDetailDTO {
 
-        @Schema(description = "인기 칼럼 게시글 아이디")
+        @Schema(description = "인기 칼럼 게시글 아이디", example = "1")
         Long popularPostId;
 
         @Schema(description = "인기 칼럼 제목")
@@ -83,5 +79,43 @@ public class HomeResponse {
 
         @Schema(description = "인기 칼럼 썸네일 이미지")
         String popularPostImage;
+    }
+
+    @ToString
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "홈 페이지 최근 검색어 정보")
+    public static class RecentSearchListDTO {
+
+        @Schema(description = "최근 검색어 리스트")
+        List <String> recentSearchList;
+    }
+
+    @ToString
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "홈 페이지 추천 검색어 정보")
+    public static class RecommendSearchListDTO {
+
+        @Schema(description = "추천 검색어 리스트")
+        List <String> recommendSearchList;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "검색어 삭제 시 반환 정보")
+    public static class SearchDeleteDTO {
+
+        @Schema(description = "검색어 삭제 성공 여부", example = "true")
+        Boolean isSearchDelete;
     }
 }

--- a/src/main/java/com/backend/farmon/dto/user/ExchangeResponse.java
+++ b/src/main/java/com/backend/farmon/dto/user/ExchangeResponse.java
@@ -1,7 +1,15 @@
 package com.backend.farmon.dto.user;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ExchangeResponse {
     @Schema(description = "전환 성공 여부, 성공일 경우 true", example = "true")
     private Boolean isExchange;


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #33 
> - #45 


## 📝작업 내용
`ChatRoom` 엔티티에서 채팅과 관련된 엔티티들(유저, 전문가, 견적)을 연결하는 부분을 추가하였고,
기존에는 홈 화면 조회 API 하나만 두어 관련된 모든 정보들을 반환하도록 작성했었는데
이를 홈화면 커뮤니티 게시글, 인기 칼럼, 최근 검색어, 추천 검색어 조회로 구분하였습니다.

추가로 채팅, 홈 화면, 농업인-전문가 전환 API 명세서에서 예외 상황에 대한 에러코드도 스웨거에 추가하였습니다. 에러 코드는 구현하면서 좀 더 명확하게 수정하겠습니다.

+) 채팅방과 연결된 전문가 아이디 expert_id는 User와 매핑시킬까 하다가 ERD 확인했을 때 견적에서 expert_id도 전문가 Expert와 연결되어 있는 것 같아서 통일성을 위해 Expert와 매핑시켰습니다!

### 스크린샷 (선택)
<img width="320" alt="image" src="https://github.com/user-attachments/assets/bc800f84-85fa-469a-bae6-ff0f94aac904" />
<img width="971" alt="image" src="https://github.com/user-attachments/assets/18d95d17-b9c8-4bbb-b81a-e21154c4a21c" />


## 💬리뷰 요구사항(선택)

> 피드백 있으시면 편하게 말씀해주세요!