### PR TITLE
✨[Feat] 문자인증/전문가 세부사항 엔티티 클래스 추가 

### DIFF
--- a/src/main/java/com/backend/farmon/domain/Expert.java
+++ b/src/main/java/com/backend/farmon/domain/Expert.java
@@ -23,25 +23,35 @@ public class Expert extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @Column(nullable = false) 와이어프레임 나오면 결정예정
     private String expertDescription; // 전문가 한줄소개
 
-//    @Column(nullable = false) 와이어프레임 나오면 결정예정
-    private Integer career;
+    private Integer availableRange;
 
-//    @Column(nullable = false) 와이어프레임 나오면 결정예정
-    private Integer availableRage;
+    private Float rating;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;  // user와 1:1관계
 
-    @OneToMany(mappedBy = "expert", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ExpertCrop> expertCropList = new ArrayList<>();
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "crop_id")
+    private Crop crop; // 전문가와 작물은 1:N관계
 
     @OneToMany(mappedBy = "expert", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ExpertArea> expertAreaList = new ArrayList<>();
 
     @OneToMany(mappedBy = "expert", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Portfolio> portfolioList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "expert", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExpertDatail> expertDatailList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "expert", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ExpertCareer> expertCareerList = new ArrayList<>();
+
+//    @OneToMany(mappedBy = "expert", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Estimate> estimateList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "expert", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatRoom> chatRoomList = new ArrayList<>();
 }

--- a/src/main/java/com/backend/farmon/domain/ExpertCareer.java
+++ b/src/main/java/com/backend/farmon/domain/ExpertCareer.java
@@ -1,6 +1,8 @@
 package com.backend.farmon.domain;
 
 import com.backend.farmon.domain.commons.BaseEntity;
+import com.backend.farmon.domain.mapping.ExpertArea;
+import com.backend.farmon.domain.mapping.ExpertCrop;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
@@ -16,7 +18,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Portfolio extends BaseEntity {
+public class ExpertCareer extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -25,15 +27,20 @@ public class Portfolio extends BaseEntity {
     private String title;
 
     @Column(nullable = false)
-    private String thumbnailImg;
+    private Integer startYear;
 
     @Column(nullable = false)
-    private String text;
+    private Integer startMonth;
+
+    @Column(nullable = false)
+    private Integer endYear;
+
+    @Column(nullable = false)
+    private Integer endMonth;
+
+    private String detailContent;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "expert_id")
     private Expert expert;
-
-    @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PortfolioImg> portfolioImgList = new ArrayList<>();
 }

--- a/src/main/java/com/backend/farmon/domain/ExpertDatail.java
+++ b/src/main/java/com/backend/farmon/domain/ExpertDatail.java
@@ -6,9 +6,6 @@ import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Entity
 @Getter
 @DynamicUpdate
@@ -16,24 +13,15 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Portfolio extends BaseEntity {
+public class ExpertDatail extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)
-    private String title;
-
-    @Column(nullable = false)
-    private String thumbnailImg;
-
-    @Column(nullable = false)
-    private String text;
+    private String detailContent;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "expert_id")
     private Expert expert;
-
-    @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PortfolioImg> portfolioImgList = new ArrayList<>();
 }

--- a/src/main/java/com/backend/farmon/domain/SmsAuth.java
+++ b/src/main/java/com/backend/farmon/domain/SmsAuth.java
@@ -1,0 +1,31 @@
+package com.backend.farmon.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@DynamicUpdate
+@DynamicInsert
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SmsAuth {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String phoneNum;
+
+    @Column(nullable = false)
+    private String authCode;
+
+    @Column(nullable = false)
+    private LocalDateTime expirationTime;
+}

--- a/src/main/java/com/backend/farmon/domain/User.java
+++ b/src/main/java/com/backend/farmon/domain/User.java
@@ -70,19 +70,27 @@ public class User extends BaseEntity {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Expert expert; // 전문가와 1:1관계
 
-//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<CharRoom> charRoomList = new ArrayList<>(); // 채팅방 양방향 매핑
-//
-//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Estimate> estimateList = new ArrayList<>();  // 견적 양방향 매핑
-//
-//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Post> postList = new ArrayList<>();  // 게시글 양방향 매핑
-//
-//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-//    private List<Like> likeList = new ArrayList<>();  // 좋아요 양방향 매핑
-//
-//    public void encodePassword(String password) {
-//        this.password = password;
-//    }
+    @OneToMany(mappedBy = "farmer", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatRoom> chatRoomList = new ArrayList<>(); // 채팅방 양방향 매핑
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Estimate> estimateList = new ArrayList<>();  // 견적 양방향 매핑
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Post> postList = new ArrayList<>();  // 게시글 양방향 매핑
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<LikeCount> likeList = new ArrayList<>();  // 좋아요 양방향 매핑
+
+    public void encodePassword(String password) {
+        this.password = password;
+    }
+
+    public void updateRole(Role role) { // 멤버 상태 변경 ex)전문가 전환
+        this.role = role;
+    }
+
+    public void updateStatus(MemberStatus status) { // 멤버 상태 변경 ex)계정 비활성화
+        this.status = status;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #53 

## 📝작업 내용
문자인증/전문가경력/전문가추가사항 엔티티 추가하였습니다.
전문가 엔티티에서 경력 속성을 제거하고 따로 전문가경력 엔티티를 만들어 1:N 매핑하였고, 전문가 추가사항 엔티티도 생성하여 전문가와 1:N 매핑해 놓았습니다. 
erdCloud도 수정사항에 맞게 추가해 놓았습니다.

+ erdCloud보고  전문가 엔티티 양방향 매핑 추가하였습니다. 견적과의 매핑은 견적엔티티에 @ManyToOne이 주석 처리 되어있어 전문가 엔티티 @OneToMany도 일단 주석처리 해놓았습니다.

## 💬리뷰 요구사항(선택)