### PR TITLE
✨[Feat] JWT 토큰 이용한 로그인/농업인 회원가입 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,11 @@ dependencies {
 
 	// 테스트 의존성
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// jwt 의존성
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
@@ -30,7 +30,10 @@ public enum ErrorStatus implements BaseErrorCode {
     CHATROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHATROOM4001", "채팅방 아이디와 일치하는 채팅방이 없습니다."),
 
     // 페이지 번호
-    PAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "PAGE4001", "페이지 번호는 1 이상이어야 합니다.");
+    PAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "PAGE4001", "페이지 번호는 1 이상이어야 합니다."),
+
+    // 회원가입 에러
+    EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "PAGE4001", "이미 가입된 이메일주소입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/backend/farmon/config/security/CustomUserDetailsService.java
+++ b/src/main/java/com/backend/farmon/config/security/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.backend.farmon.config.security;
+
+import com.backend.farmon.apiPayload.code.status.ErrorStatus;
+import com.backend.farmon.apiPayload.exception.handler.UserHandler;
+import com.backend.farmon.domain.User;
+import com.backend.farmon.dto.user.CustomUserDetails;
+import com.backend.farmon.repository.UserRepository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    // DB에서 유저 정보 찾아내서 UserDetail생성하는 메서드
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        // 해당 이메일과 일치하는 유저 없을시 에러 발생
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.EMAIL_ALREADY_EXIST));
+
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/com/backend/farmon/config/security/JWTAuthenticationFilter.java
+++ b/src/main/java/com/backend/farmon/config/security/JWTAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.backend.farmon.config.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class JWTAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private JWTUtil tokenGenerator;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        try {
+            String token = getJWTFromRequest(request);  // token parsing
+
+            if (StringUtils.hasText(token) && tokenGenerator.validateToken(token)) {// 토큰 유효성 검사
+                Long userId = tokenGenerator.extractUserId(token);  // userId 추출
+                String role = tokenGenerator.extractRole(token);    // role 추출
+
+//                // 로그로 추출한 데이터 출력
+//                logger.info(String.format("Authenticated User ID: %s, Role: %s", userId, role));
+
+                // 인증 정보 생성
+                GrantedAuthority authority = new SimpleGrantedAuthority(role);
+                AbstractAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                        userId,  // userId를 principal로 설정
+                        null,  // 자격증명은 없으므로 null
+                        Collections.singletonList(authority)  // 권한 설정
+                );
+
+                authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                // SecurityContext에 인증 정보 설정 (이제 이 사용자는 인증된 사용자로 간주됨)
+                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+            }
+        } catch (Exception e) {
+            logger.error("Invalid JWT token: " + e.getMessage());
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJWTFromRequest(HttpServletRequest request) {
+        // "Authorization" 헤더에서 "Bearer" 접두어 제거하고 토큰 추출
+        String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            return header.substring(7, header.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/backend/farmon/config/security/JWTUtil.java
+++ b/src/main/java/com/backend/farmon/config/security/JWTUtil.java
@@ -1,0 +1,68 @@
+package com.backend.farmon.config.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    @Value("${spring.jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.jwt.expiration-time}")
+    private long expirationTime;
+
+    // 로그인 응답으로 반환할 JWT 토큰 생성
+    public String generateToken(String email, Long userId, String role) {
+        return Jwts.builder()
+                .setSubject(email)
+                .claim("userId", userId)
+                .claim("role", role)
+                .setIssuedAt(new Date()) // 토큰 발행시간
+                .setExpiration(new Date(System.currentTimeMillis() + expirationTime)) // 토큰 만료시간
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    // JWT에서 email 추출
+    public String extractEmail(String token) {
+        Claims claims = extractAllClaims(token);
+        return claims.getSubject();
+    }
+
+    // JWT에서 userId 추출
+    public Long extractUserId(String token) {
+        Claims claims = extractAllClaims(token);  // Claims 객체 추출
+        return claims.get("userId", Long.class);  // "userId" 클레임에서 값을 추출
+    }
+
+    // JWT에서 role 추출
+    public String extractRole(String token) {
+        Claims claims = extractAllClaims(token);  // Claims 객체 추출
+        return claims.get("role", String.class);  // "role" 클레임에서 값을 추출
+    }
+
+    // 토큰에서 클레임 정보 추출
+    private Claims extractAllClaims(String token) {
+        return Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    // 토큰 검증
+    public Boolean validateToken(String token) {
+        try{
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+            return true;
+        }catch (Exception e){
+            throw new AuthenticationCredentialsNotFoundException("JWT 토큰이 만료되었거나 잘못되었습니다.");
+        }
+    }
+}

--- a/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
+++ b/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
@@ -3,26 +3,48 @@ package com.backend.farmon.config.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @RequiredArgsConstructor
 @EnableWebSecurity // Spring Security 설정 활성화
 @Configuration
 public class SecurityConfig { // 애플리케이션의 보안 정책을 정의
+    private CustomUserDetailsService userDetailsService;
 
     // SecurityFilterChain 정의
     // 추후에 농업인 관련 페이지는 농업인만, 전문가 관련 페이지는 전문가만 가입할 수 있도록 수정 필요
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .authorizeHttpRequests((requests) -> requests
-                        .anyRequest().permitAll() // 모든 요청을 인증 없이 접근 가능하도록 설정
+                .csrf((auth) -> auth.disable()) // 필요 시 CSRF 보호 비활성화
+                .formLogin((auth) -> auth.disable()) // form 로그인 방식 disable
+                .httpBasic((auth) -> auth.disable()) // http Basic 인증 방식 disable
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 STATELESS 상태로 설정
+                .authorizeHttpRequests((auth) -> auth
+//                        // FARMER 역할만 접근 가능
+//                        .requestMatchers("/farmer/**").hasRole("FARMER")
+//
+//                        // EXPERT 역할만 접근 가능
+//                        .requestMatchers("/expert/**").hasRole("EXPERT")
+//
+//                        // 인증된 사용자(로그인한 사용자)만 접근 가능
+//                        .requestMatchers("/").authenticated()
+
+                        // 공용 접근 허용 (누구나 접근 가능)
+                        .requestMatchers("/**","/api/login","/api/user/join","/api/expert/join").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll() // Swagger 경로 허용
+                        .anyRequest().authenticated()
                 )
-                .csrf().disable(); // 필요 시 CSRF 보호 비활성화
+
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);  // JWT 필터 추가
 
         return http.build();
     }
@@ -31,5 +53,16 @@ public class SecurityConfig { // 애플리케이션의 보안 정책을 정의
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    // 커스텀 필터에 주입할 AuthenticationManager Bean 등록
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JWTAuthenticationFilter jwtAuthenticationFilter() {
+        return new JWTAuthenticationFilter();
     }
 }

--- a/src/main/java/com/backend/farmon/config/security/UserAuthorizationUtil.java
+++ b/src/main/java/com/backend/farmon/config/security/UserAuthorizationUtil.java
@@ -1,0 +1,44 @@
+package com.backend.farmon.config.security;
+
+import com.backend.farmon.repository.UserRepository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UserAuthorizationUtil {
+
+    private final UserRepository userRepository;
+
+    // 현재 로그인한 유저의 userId 반환해주는 메서드
+    public Long getCurrentUserId() {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new AuthenticationCredentialsNotFoundException("Authentication or principal is null");
+        }
+        Long userId = (Long) authentication.getPrincipal();
+        return userId;
+    }
+
+    // 현재 로그인한 유저의 role 반환해주는 메서드
+    public String getCurrentUserRole() {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new AuthenticationCredentialsNotFoundException("Authentication or principal is null");
+        }
+        GrantedAuthority authority = authentication.getAuthorities().stream()
+                .findFirst()
+                .orElseThrow(() -> new AuthenticationCredentialsNotFoundException("No roles found for the authenticated user"));
+
+        return authority.getAuthority();
+    }
+
+}

--- a/src/main/java/com/backend/farmon/controller/LoginController.java
+++ b/src/main/java/com/backend/farmon/controller/LoginController.java
@@ -3,6 +3,7 @@ package com.backend.farmon.controller;
 import com.backend.farmon.apiPayload.ApiResponse;
 import com.backend.farmon.dto.user.LoginRequestDTO;
 import com.backend.farmon.dto.user.LoginResponseDTO;
+import com.backend.farmon.service.UserService.LoginService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,10 +12,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "로그인")
+@Tag(name = "로그인", description = "로그인에 관한 API. userId와 토큰을 반환합니다.")
 @RestController
 @RequiredArgsConstructor
 public class LoginController {
+
+    private final LoginService loginService;
 
     @PostMapping("/api/login")
     @Operation(summary = "공동로그인 API")
@@ -22,8 +25,7 @@ public class LoginController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
     })
     public ApiResponse<LoginResponseDTO> login(@RequestBody LoginRequestDTO loginRequestDTO) {
-        return null;
+        LoginResponseDTO resultDTO = loginService.attemptLogin(loginRequestDTO.getEmail(), loginRequestDTO.getPassword());
+        return ApiResponse.onSuccess(resultDTO);
     }
-
-
 }

--- a/src/main/java/com/backend/farmon/controller/SignupController.java
+++ b/src/main/java/com/backend/farmon/controller/SignupController.java
@@ -1,29 +1,34 @@
 package com.backend.farmon.controller;
 
 import com.backend.farmon.apiPayload.ApiResponse;
+import com.backend.farmon.converter.SignupConverter;
+import com.backend.farmon.domain.User;
 import com.backend.farmon.dto.user.SignupRequest;
 import com.backend.farmon.dto.user.SignupResponse;
+import com.backend.farmon.service.UserService.UserCommandService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "회원가입")
+@Tag(name = "회원가입", description = "회원가입에 관한 API")
 @RestController
 @RequiredArgsConstructor
 public class SignupController {
+    private final UserCommandService userCommandService;
 
     @PostMapping("/api/user/join")
     @Operation(summary = "농업인 회원가입 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
     })
-    public ApiResponse<SignupResponse.JoinResultDTO> userJoin(@RequestBody SignupRequest.UserJoinDto userJoinDto){
-
-        return null;
+    public ApiResponse<SignupResponse.JoinResultDTO> userJoin(@Valid @RequestBody SignupRequest.UserJoinDto userJoinDto){
+        User user = userCommandService.joinUser(userJoinDto);
+        return ApiResponse.onSuccess(SignupConverter.toJoinResultDTO(user));// 저장된 엔티티로 응답 DTO생성후 반환
     }
 
     @PostMapping("/api/expert/join")

--- a/src/main/java/com/backend/farmon/converter/SignupConverter.java
+++ b/src/main/java/com/backend/farmon/converter/SignupConverter.java
@@ -1,0 +1,30 @@
+package com.backend.farmon.converter;
+
+import com.backend.farmon.domain.User;
+import com.backend.farmon.dto.user.SignupRequest;
+import com.backend.farmon.dto.user.SignupResponse;
+
+import java.time.LocalDateTime;
+
+public class SignupConverter {
+
+    // 농업인 회원가입시 엔티티 생성
+    public static User toUser(SignupRequest.UserJoinDto request){
+        return User.builder()
+                .userName(request.getName())
+                .gender(request.getGender())
+                .birthDate(request.getBirth())
+                .email(request.getEmail())
+                .phoneNum(request.getPhone())
+                // .role(request.getRole()) 기본적으로 농업인으로 설정됨
+                .build();
+    }
+
+    // 농업인 회원가입시 응답 DTO 생성
+    public static SignupResponse.JoinResultDTO toJoinResultDTO(User user){
+        return SignupResponse.JoinResultDTO.builder()
+                .userId(user.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/backend/farmon/domain/User.java
+++ b/src/main/java/com/backend/farmon/domain/User.java
@@ -86,10 +86,6 @@ public class User extends BaseEntity {
         this.password = password;
     }
 
-    public void updateRole(Role role) { // 멤버 상태 변경 ex)전문가 전환
-        this.role = role;
-    }
-
     public void updateStatus(MemberStatus status) { // 멤버 상태 변경 ex)계정 비활성화
         this.status = status;
     }

--- a/src/main/java/com/backend/farmon/dto/user/CustomUserDetails.java
+++ b/src/main/java/com/backend/farmon/dto/user/CustomUserDetails.java
@@ -1,0 +1,65 @@
+package com.backend.farmon.dto.user;
+
+import com.backend.farmon.domain.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override // 유저의 권한(Role)을 반환 해주는 메소드
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        GrantedAuthority authority = new SimpleGrantedAuthority(user.getRole().toString());
+        collection.add(authority);
+
+        return collection;
+    }
+
+    @Override  // 유저의 비밀번호 반환
+    public String getPassword() {
+
+        return user.getPassword();
+    }
+
+    @Override  // 유저의 이름(이메일) 반환
+    public String getUsername() {
+
+        return user.getEmail();
+    }
+
+    @Override // 계정 만료 여부
+    public boolean isAccountNonExpired() {
+
+        return true;
+    }
+
+    @Override // 계정 잠금 여부
+    public boolean isAccountNonLocked() {
+
+        return true;
+    }
+
+    @Override // 자격증명 만료 여부
+    public boolean isCredentialsNonExpired() {
+
+        return true;
+    }
+
+    @Override // 사용자 활성화 여부
+    public boolean isEnabled() {
+
+        return true;
+    }
+}

--- a/src/main/java/com/backend/farmon/dto/user/LoginResponseDTO.java
+++ b/src/main/java/com/backend/farmon/dto/user/LoginResponseDTO.java
@@ -7,6 +7,6 @@ import lombok.*;
 @Getter
 @Setter
 public class LoginResponseDTO {
-    private String userId;
-    private String role;
+    private Long userId;
+    private String token;
 }

--- a/src/main/java/com/backend/farmon/dto/user/SignupRequest.java
+++ b/src/main/java/com/backend/farmon/dto/user/SignupRequest.java
@@ -1,6 +1,10 @@
 package com.backend.farmon.dto.user;
 
+import com.backend.farmon.domain.enums.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -16,23 +20,31 @@ public class SignupRequest {
     @Schema(description = "농업인(일반 회원) 회원가입 요청 DTO")
     public static class UserJoinDto{
         @Schema(description = "이름", example = "홍길동")
+        @NotBlank
         String name;
 
         @Schema(description = "생년월일", example = "2025-01-01")
+        @NotNull
         LocalDate birth;
 
         @Schema(description = "성별 (MALE,FEMALE) ", example = "MALE")
-        String gender;  // String으로 받되, 후에 Enum으로 변환
+        @NotNull
+        Gender gender;
 
         @Schema(description = "이메일 주소", example = "umc@gmail.com")
+        @NotBlank
+        @Email
         String email;
 
         @Schema(description = "비밀번호", example = "qwer1234")
+        @NotBlank
         String password;
 
         @Schema(description = "휴대전화번호", example = "01012345678")
+        @NotBlank
         String phone;
     }
+
 
     @Builder
     @Getter

--- a/src/main/java/com/backend/farmon/repository/UserRepository/UserRepository.java
+++ b/src/main/java/com/backend/farmon/repository/UserRepository/UserRepository.java
@@ -3,5 +3,9 @@ package com.backend.farmon.repository.UserRepository;
 import com.backend.farmon.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
+    Boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/backend/farmon/service/UserService/LoginService.java
+++ b/src/main/java/com/backend/farmon/service/UserService/LoginService.java
@@ -1,0 +1,47 @@
+package com.backend.farmon.service.UserService;
+
+import com.backend.farmon.apiPayload.code.status.ErrorStatus;
+import com.backend.farmon.apiPayload.exception.handler.UserHandler;
+import com.backend.farmon.config.security.JWTUtil;
+import com.backend.farmon.domain.User;
+import com.backend.farmon.dto.user.LoginResponseDTO;
+import com.backend.farmon.repository.UserRepository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+
+    private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+    private final JWTUtil jwtUtil;
+    private final PasswordEncoder passwordEncoder;
+
+    // 로그인 요청 (이메일, 비밀번호 확인 후 JWT 생성)
+    @Transactional
+    public LoginResponseDTO attemptLogin(String email, String password) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // authenticationManager에서 사용자 인증 후 authentication객체에 저장
+        Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(email, password));
+        // SecurityContext에 인증 정보 저장
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // 앞으로 로그인시 사용될 jwt token 생성
+        String token = jwtUtil.generateToken(user.getEmail(), user.getId(), user.getRole().toString());
+
+        // 응답 DTO 생성
+        return LoginResponseDTO.builder()
+                .userId(user.getId())
+                .token(token)
+                .build();
+    }
+}

--- a/src/main/java/com/backend/farmon/service/UserService/UserCommandService.java
+++ b/src/main/java/com/backend/farmon/service/UserService/UserCommandService.java
@@ -1,0 +1,8 @@
+package com.backend.farmon.service.UserService;
+
+import com.backend.farmon.domain.User;
+import com.backend.farmon.dto.user.SignupRequest;
+
+public interface UserCommandService {
+    User joinUser(SignupRequest.UserJoinDto request);
+}

--- a/src/main/java/com/backend/farmon/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/UserService/UserCommandServiceImpl.java
@@ -1,0 +1,34 @@
+package com.backend.farmon.service.UserService;
+
+import com.backend.farmon.apiPayload.code.status.ErrorStatus;
+import com.backend.farmon.apiPayload.exception.handler.UserHandler;
+import com.backend.farmon.converter.SignupConverter;
+import com.backend.farmon.domain.User;
+import com.backend.farmon.dto.user.SignupRequest;
+import com.backend.farmon.repository.UserRepository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserCommandServiceImpl implements UserCommandService{
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public User joinUser(SignupRequest.UserJoinDto request) {
+        Boolean emailExists = userRepository.existsByEmail(request.getEmail());
+        if(emailExists) {
+            throw new UserHandler(ErrorStatus.EMAIL_ALREADY_EXIST);
+        }
+
+        User newUser = SignupConverter.toUser(request);
+        newUser.encodePassword(passwordEncoder.encode(request.getPassword()));
+
+        return userRepository.save(newUser);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #60 

## 📝작업 내용

로그인/농업인 회원가입 api 구현 완료하였습니다.
jwt토큰을 헤더로 받는 api에서 사용자 인증을 진행합니다.
스웨거에서 헤더로 jwt받는 api를 테스트할땐, Authorize에 로그인시 발급받은 토큰 데이터 넣은 뒤 테스트 해주세요.

UserAuthorizationUtil 객체를 주입하시면 jwt 토큰으로 받은 userId와 role을 사용하실 수 있습니다. 
예시)
![image](https://github.com/user-attachments/assets/0f57632a-935f-4f4a-a537-8b1f2a984d38)

application.yml파일에 jwt관련 사항 추가해주세요. spring 하위에 추가해주시면 됩니다. 
머지되면 노션 배포 관련 사항에 추가해두도록 하겠습니다!
![image](https://github.com/user-attachments/assets/28f994bc-e7fa-4329-8b4e-abbcfa07acac)
  # jwt
  jwt:
    secret-key: vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb
    expiration-time: 3600000 

## 💬리뷰 요구사항(선택)
> 토큰 이용한 로그인은 처음이라 완벽하지 않은 부분이 많습니다. 편하게 피드백 주세요!