### PR TITLE
✨[Feat] 홈화면 인기 전문가 칼럼 게시글 조회 추가

### DIFF
--- a/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
@@ -34,7 +34,10 @@ public enum ErrorStatus implements BaseErrorCode {
     PAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "PAGE4001", "페이지 번호는 1 이상이어야 합니다."),
 
     // 회원가입 에러
-    EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "PAGE4001", "이미 가입된 이메일주소입니다.");
+    EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "PAGE4001", "이미 가입된 이메일주소입니다."),
+
+    // 커뮤니티 게시판
+    POST_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_TYPE4001", "지원되지 않는 게시판 타입 입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/backend/farmon/apiPayload/exception/handler/PostTypeHandler.java
+++ b/src/main/java/com/backend/farmon/apiPayload/exception/handler/PostTypeHandler.java
@@ -1,0 +1,11 @@
+package com.backend.farmon.apiPayload.exception.handler;
+
+import com.backend.farmon.apiPayload.code.BaseErrorCode;
+import com.backend.farmon.apiPayload.exception.GeneralException;
+
+public class PostTypeHandler extends GeneralException  {
+    public PostTypeHandler(BaseErrorCode code) {
+        super(code);
+    }
+
+}

--- a/src/main/java/com/backend/farmon/config/security/JWTUtil.java
+++ b/src/main/java/com/backend/farmon/config/security/JWTUtil.java
@@ -3,6 +3,7 @@ package com.backend.farmon.config.security;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.stereotype.Component;
@@ -64,5 +65,24 @@ public class JWTUtil {
         }catch (Exception e){
             throw new AuthenticationCredentialsNotFoundException("JWT 토큰이 만료되었거나 잘못되었습니다.");
         }
+    }
+
+    // 농업인 - 전문가 전환을 위해 역할이 변경된 새로운 토큰을 생성
+    public String updateRoleInToken(String token, String newRole) {
+        Claims claims = extractAllClaims(token); // 기존 토큰에서 클레임 추출
+        String email = claims.getSubject();     // 기존 이메일
+        Long userId = claims.get("userId", Long.class); // 기존 userId
+
+        // 새 Role로 새로운 토큰 생성
+        return generateToken(email, userId, newRole);
+    }
+
+    // HTTP 요청에서 JWT 토큰 추출
+    public String extractTokenFromRequest(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            return header.substring(7); // "Bearer " 이후의 토큰 반환
+        }
+        throw new AuthenticationCredentialsNotFoundException("JWT 토큰이 요청 헤더에 없습니다.");
     }
 }

--- a/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
+++ b/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig { // 애플리케이션의 보안 정책을 정의
 //                        .requestMatchers("/").authenticated()
 
                         // 공용 접근 허용 (누구나 접근 가능)
-                        .requestMatchers("/**","/api/login","/api/user/join","/api/expert/join").permitAll()
+                        .requestMatchers("/**","/api/login","/api/user/join","/api/expert/join", "/api/home/community", "/api/home/popular").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll() // Swagger 경로 허용
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -27,21 +27,19 @@ public class HomeController {
     @Operation(
             summary = "홈 화면 커뮤니티 게시글 조회 API",
             description = "홈 화면에서 커뮤니티 카테고리에 따른 게시글을 조회합니다. " +
-                    "필터링 할 커뮤니티 카테고리 이름을 쿼리 스트링으로 입력해 주세요. " +
-                    "로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
+                    "필터링 할 커뮤니티 카테고리 이름을 쿼리 스트링으로 입력해 주세요. "
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST_TYPE4001", description = "지원되지 않는 게시판 타입 입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
-            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1"),
-            @Parameter(name = "category", description = "커뮤니티 카테고리 이름", example = "인기", required = true)
+            @Parameter(name = "category", description = "커뮤니티 카테고리 이름", example = "POPULAR", required = true)
     })
     @GetMapping("/community")
     public ApiResponse<HomeResponse.PostListDTO> getHomePostsByCategory (@RequestParam(name = "userId", required = false) Long userId,
-                                                                         @RequestParam(name = "category") PostType category){
+                                                                         @RequestParam(name = "category", defaultValue = "POPULAR") PostType category){
         HomeResponse.PostListDTO response = postQueryService.findHomePostsByCategory(userId, category);
         return ApiResponse.onSuccess(response);
     }
@@ -50,18 +48,14 @@ public class HomeController {
     // 홈 화면 - 인기 칼럼 조회
     @Operation(
             summary = "홈 화면 인기 칼럼 조회 API",
-            description = "홈 화면에서 인기 칼럼 게시글 목록을 조회합니다. 로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
+            description = "홈 화면에서 인기 칼럼 게시글 목록을 조회합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
-    @Parameters({
-            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1"),
-    })
     @GetMapping("/popular")
-    public ApiResponse<HomeResponse.PopularPostListDTO> getHomePopularPosts (@RequestParam(name = "userId", required = false) Long userId){
+    public ApiResponse<HomeResponse.PopularPostListDTO> getHomePopularPosts (){
         HomeResponse.PopularPostListDTO response = HomeResponse.PopularPostListDTO.builder().build();;
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -47,7 +47,7 @@ public class HomeController {
     // 홈 화면 - 인기 칼럼 조회
     @Operation(
             summary = "홈 화면 인기 칼럼 조회 API",
-            description = "홈 화면에서 인기 칼럼 게시글 목록을 조회합니다."
+            description = "홈 화면에서 인기 칼럼 게시글 목록을 6개 조회합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -55,7 +55,7 @@ public class HomeController {
     })
     @GetMapping("/popular")
     public ApiResponse<HomeResponse.PopularPostListDTO> getHomePopularPosts (){
-        HomeResponse.PopularPostListDTO response = HomeResponse.PopularPostListDTO.builder().build();;
+        HomeResponse.PopularPostListDTO response = postQueryService.findPopularExpertColumnPosts();
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -38,9 +38,8 @@ public class HomeController {
             @Parameter(name = "category", description = "커뮤니티 카테고리 이름", example = "POPULAR", required = true)
     })
     @GetMapping("/community")
-    public ApiResponse<HomeResponse.PostListDTO> getHomePostsByCategory (@RequestParam(name = "userId", required = false) Long userId,
-                                                                         @RequestParam(name = "category", defaultValue = "POPULAR") PostType category){
-        HomeResponse.PostListDTO response = postQueryService.findHomePostsByCategory(userId, category);
+    public ApiResponse<HomeResponse.PostListDTO> getHomePostsByCategory (@RequestParam(name = "category", defaultValue = "POPULAR") PostType category){
+        HomeResponse.PostListDTO response = postQueryService.findHomePostsByCategory(category);
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/backend/farmon/controller/UserController.java
+++ b/src/main/java/com/backend/farmon/controller/UserController.java
@@ -76,8 +76,6 @@ public class UserController {
                                                          HttpServletRequest request) {
         // JWTUtil을 통해 토큰 추출
         String token = jwtUtil.extractTokenFromRequest(request);
-        log.info("Extracted Token: {}", token);
-
         ExchangeResponse response = userQueryService.exchangeRole(userId, role, token);
 
         return ApiResponse.onSuccess(response);

--- a/src/main/java/com/backend/farmon/controller/UserController.java
+++ b/src/main/java/com/backend/farmon/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.backend.farmon.controller;
 
 import com.backend.farmon.apiPayload.ApiResponse;
+import com.backend.farmon.config.security.JWTUtil;
 import com.backend.farmon.domain.enums.Role;
 import com.backend.farmon.dto.user.ExchangeResponse;
 import com.backend.farmon.dto.user.MypageRequest;
@@ -13,15 +14,19 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @Tag(name = "사용자 정보")
 @RestController
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserQueryService userQueryService;
+    private final JWTUtil jwtUtil;
 
     @GetMapping("/api/user/{id}")
     @Operation(summary = "마이페이지 조회 API")
@@ -50,22 +55,30 @@ public class UserController {
     @GetMapping("/api/user/exchange")
     @Operation(
             summary = "사용자 역할 전환 API",
-            description = "농업인 전환과 전문가 전환에 관한 API 입니다. 농업인일 경우 전문가로 전환, 전문가일 경우 농업인으로 전환에 필요한 데이터를 반환합니다. " +
-                    "유저 아이디, 사용자 유형을 쿼리 스트링으로 입력해주세요."
+            description = "농업인 전환과 전문가 전환에 관한 API 입니다. 농업인일 경우 전문가로 전환, 전문가일 경우 농업인으로 전환되어 새로운 토큰을 발급합니다. "
+                    + "요청 성공 시 새로 발급된 토큰을 요청 헤더에 넣어주세요."
+                    + "유저 아이디, 사용자 유형을 쿼리 스트링으로 입력해주세요."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "EXPERT4002", description = "전문가로 등록되어 있지 않은 농업인 입니다. (농업인 -> 전문가 전환 시 전문가로 등록되어 있지 않은 사용자일 때)", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON500", description = "전환하려는 역할과 현재 로그인한 역할이 일치합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON500", description = "JWT 토큰이 요청 헤더에 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
-            @Parameter(name = "role", description = "전환하고자 하는 사용자 유형(ADMIN 제외)")
+            @Parameter(name = "role", description = "전환하고자 하는 사용자 유형(ADMIN 제외), 전문가 전환 시 EXPERT, 농업인 전환 시 FARMER", example = "EXPERT")
     })
     public ApiResponse<ExchangeResponse> getExchangeRole(@RequestParam(name="userId") Long userId,
-                                                         @RequestParam(name="role") Role role) {
-        ExchangeResponse response = userQueryService.exchangeRole(userId, role);
+                                                         @RequestParam(name="role", defaultValue = "EXPERT") Role role,
+                                                         HttpServletRequest request) {
+        // JWTUtil을 통해 토큰 추출
+        String token = jwtUtil.extractTokenFromRequest(request);
+        log.info("Extracted Token: {}", token);
+
+        ExchangeResponse response = userQueryService.exchangeRole(userId, role, token);
 
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/backend/farmon/converter/HomeConverter.java
+++ b/src/main/java/com/backend/farmon/converter/HomeConverter.java
@@ -46,7 +46,12 @@ public class HomeConverter {
                 .popularPostContent(post.getPostContent())
                 .writer(post.getUser().getUserName())
                 .profileImage(post.getUser().getExpert().getProfileImageUrl())
-                .popularPostImage(post.getPostImgs().get(0).getStoredFileName())
+                // 게시글 이미지 가져오기
+                .popularPostImage(
+                        (post.getPostImgs() != null && !post.getPostImgs().isEmpty())
+                                ? post.getPostImgs().get(0).getStoredFileName()
+                                : null
+                )
                 .build();
     }
 }

--- a/src/main/java/com/backend/farmon/converter/HomeConverter.java
+++ b/src/main/java/com/backend/farmon/converter/HomeConverter.java
@@ -28,4 +28,25 @@ public class HomeConverter {
                 .commentCount(commentCount)
                 .build();
     }
+
+    public static HomeResponse.PopularPostListDTO toPopularPostListDTO(List<Post> postList) {
+        List<HomeResponse.PopularPostDetailDTO> popularPostDetailDTOList = postList.stream()
+                .map(HomeConverter::toPopularPostDetailListDTO)
+                .toList();
+
+        return HomeResponse.PopularPostListDTO.builder()
+                .popularPostList(popularPostDetailDTOList)
+                .build();
+    }
+
+    public static HomeResponse.PopularPostDetailDTO toPopularPostDetailListDTO(Post post) {
+        return HomeResponse.PopularPostDetailDTO.builder()
+                .popularPostId(post.getId())
+                .popularPostTitle(post.getPostTitle())
+                .popularPostContent(post.getPostContent())
+                .writer(post.getUser().getUserName())
+                .profileImage(post.getUser().getExpert().getProfileImageUrl())
+                .popularPostImage(post.getPostImgs().get(0).getStoredFileName())
+                .build();
+    }
 }

--- a/src/main/java/com/backend/farmon/converter/UserConverter.java
+++ b/src/main/java/com/backend/farmon/converter/UserConverter.java
@@ -5,10 +5,11 @@ import com.backend.farmon.domain.enums.Role;
 import com.backend.farmon.dto.user.ExchangeResponse;
 
 public class UserConverter {
-    public static ExchangeResponse toExchangeResponse(Long userId, Role role, Expert expert) {
+    public static ExchangeResponse toExchangeResponse(Long userId, String role, Expert expert, String token) {
         ExchangeResponse.ExchangeResponseBuilder responseBuilder = ExchangeResponse.builder()
                 .userId(userId)
-                .exchangeRole(role.name());
+                .exchangeRole(role)
+                .token(token);
 
         // 전문가로 등록되어 있는 사용자라면 전문가 아이디도 반환
         if (expert != null) {

--- a/src/main/java/com/backend/farmon/dto/user/ExchangeResponse.java
+++ b/src/main/java/com/backend/farmon/dto/user/ExchangeResponse.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ExchangeResponse {
 
-    @Schema(description = "전환에 성공한 역할, 농업인 전환일 경우 FARMER, 전문가 전환일 경우 EXPERT", example = "EXPERT")
+    @Schema(description = "전환에 성공한 역할, 농업인 전환일 경우 String 타입으로 FARMER, 전문가 전환일 경우 EXPERT", example = "EXPERT")
     private String exchangeRole;
 
     @Schema(description = "유저 아이디")
@@ -20,4 +20,7 @@ public class ExchangeResponse {
 
     @Schema(description = "전문가 아이디, 전문가로 등록된 사용자일 경우에만 반환")
     private Long expertId;
+
+    @Schema(description = "역할 전환으로 인해 새로 발급된 토큰, 앞으로는 해당 토큰을 해더에 포함시키면 됩니다.")
+    private String token;
 }

--- a/src/main/java/com/backend/farmon/repository/PostRepository/PostRepositoryCustom.java
+++ b/src/main/java/com/backend/farmon/repository/PostRepository/PostRepositoryCustom.java
@@ -14,4 +14,7 @@ public interface PostRepositoryCustom {
 
     // 커뮤니티 카테고리별 게시글 3개 조회
     public List<Post> findTop3PostsByPostTYpe(PostType postType);
+
+    // 인기 전문가 칼럼 6개 조회
+    public List<Post> findTop6ExpertColumnPostsByPostId(List<Long> popularPostsIdList);
 }

--- a/src/main/java/com/backend/farmon/repository/PostRepository/PostRepositoryCustom.java
+++ b/src/main/java/com/backend/farmon/repository/PostRepository/PostRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.backend.farmon.repository.PostRepository;
 
 import com.backend.farmon.domain.Post;
+import com.backend.farmon.dto.post.PostType;
 
 import java.util.List;
 
@@ -10,4 +11,7 @@ public interface PostRepositoryCustom {
 
     // 커뮤니티 인기 게시글 3개 조회
     public List<Post> findTop3PostsByLikes();
+
+    // 커뮤니티 카테고리별 게시글 3개 조회
+    public List<Post> findTop3PostsByPostTYpe(PostType postType);
 }

--- a/src/main/java/com/backend/farmon/repository/PostRepository/PostRepositoryCustom.java
+++ b/src/main/java/com/backend/farmon/repository/PostRepository/PostRepositoryCustom.java
@@ -14,7 +14,4 @@ public interface PostRepositoryCustom {
 
     // 커뮤니티 카테고리별 게시글 3개 조회
     public List<Post> findTop3PostsByPostTYpe(PostType postType);
-
-    // 인기 전문가 칼럼 6개 조회
-    public List<Post> findTop6ExpertColumnPostsByPostId(List<Long> popularPostsIdList);
 }

--- a/src/main/java/com/backend/farmon/repository/PostRepository/PostRepositoryImpl.java
+++ b/src/main/java/com/backend/farmon/repository/PostRepository/PostRepositoryImpl.java
@@ -5,7 +5,6 @@ import com.backend.farmon.domain.QBoard;
 import com.backend.farmon.domain.QLikeCount;
 import com.backend.farmon.domain.QPost;
 import com.backend.farmon.dto.post.PostType;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -33,22 +32,27 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     @Override
     public List<Post> findTop3PostsByLikes() {
         return queryFactory.selectFrom(post)
-                .join(post.postlikes, likeCount).fetchJoin()
+                .leftJoin(post.postlikes, likeCount).fetchJoin()
                 .groupBy(post)
                 .orderBy(likeCount.count().desc(), post.createdAt.desc())
                 .limit(3)
                 .fetch();
     }
 
-    // 커뮤니티 카테고리별 게시글 3개 조회
     @Override
     public List<Post> findTop3PostsByPostTYpe(PostType postType) {
-        return queryFactory.selectFrom(post)
-                .join(post.board, board).fetchJoin() // Post와 Board를 조인
+        return queryFactory.select(post)
+                .from(post)
+                .join(post.board, board) // Post와 Board를 조인
+                .leftJoin(post.postlikes, likeCount) // Post와 LikeCount를 조인
                 .where(board.postType.eq(postType)) // PostType으로 필터링
-                .groupBy(post)
-                .orderBy(likeCount.count().desc(), post.createdAt.desc())
+                .groupBy(post) // Post별로 그룹화
+                .orderBy(
+                        likeCount.count().desc(), // 좋아요 개수로 정렬
+                        post.createdAt.desc() // 최신순 정렬
+                )
                 .limit(3) // 3개 제한
                 .fetch();
     }
+
 }

--- a/src/main/java/com/backend/farmon/repository/PostRepository/PostRepositoryImpl.java
+++ b/src/main/java/com/backend/farmon/repository/PostRepository/PostRepositoryImpl.java
@@ -1,8 +1,10 @@
 package com.backend.farmon.repository.PostRepository;
 
 import com.backend.farmon.domain.Post;
+import com.backend.farmon.domain.QBoard;
 import com.backend.farmon.domain.QLikeCount;
 import com.backend.farmon.domain.QPost;
+import com.backend.farmon.dto.post.PostType;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -15,6 +17,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     QPost post = QPost.post;
     QLikeCount likeCount = QLikeCount.likeCount;
+    QBoard board = QBoard.board;
 
     // 커뮤니티 전체 게시글 3개 조회
     @Override
@@ -33,6 +36,17 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .groupBy(post)
                 .orderBy(likeCount.count().desc(), post.createdAt.desc())
                 .limit(3)
+                .fetch();
+    }
+
+    // 커뮤니티 카테고리별 게시글 3개 조회
+    @Override
+    public List<Post> findTop3PostsByPostTYpe(PostType postType) {
+        return queryFactory.selectFrom(post)
+                .join(post.board, board).fetchJoin() // Post와 Board를 조인
+                .where(board.postType.eq(postType)) // PostType으로 필터링
+                .orderBy(post.createdAt.desc()) // 최신순 정렬
+                .limit(3) // 3개 제한
                 .fetch();
     }
 }

--- a/src/main/java/com/backend/farmon/repository/PostRepository/PostRepositoryImpl.java
+++ b/src/main/java/com/backend/farmon/repository/PostRepository/PostRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.backend.farmon.domain.QBoard;
 import com.backend.farmon.domain.QLikeCount;
 import com.backend.farmon.domain.QPost;
 import com.backend.farmon.dto.post.PostType;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -32,7 +33,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     @Override
     public List<Post> findTop3PostsByLikes() {
         return queryFactory.selectFrom(post)
-                .leftJoin(post.postlikes, likeCount)
+                .join(post.postlikes, likeCount).fetchJoin()
                 .groupBy(post)
                 .orderBy(likeCount.count().desc(), post.createdAt.desc())
                 .limit(3)
@@ -45,7 +46,8 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         return queryFactory.selectFrom(post)
                 .join(post.board, board).fetchJoin() // Post와 Board를 조인
                 .where(board.postType.eq(postType)) // PostType으로 필터링
-                .orderBy(post.createdAt.desc()) // 최신순 정렬
+                .groupBy(post)
+                .orderBy(likeCount.count().desc(), post.createdAt.desc())
                 .limit(3) // 3개 제한
                 .fetch();
     }

--- a/src/main/java/com/backend/farmon/service/PostService/PostQueryService.java
+++ b/src/main/java/com/backend/farmon/service/PostService/PostQueryService.java
@@ -6,5 +6,5 @@ import com.backend.farmon.dto.post.PostType;
 public interface PostQueryService {
 
     // 홈 화면 카테고리에 따른 커뮤니티 게시글 3개씩 조회
-    HomeResponse.PostListDTO findHomePostsByCategory(Long userId, PostType category);
+    HomeResponse.PostListDTO findHomePostsByCategory(PostType category);
 }

--- a/src/main/java/com/backend/farmon/service/PostService/PostQueryService.java
+++ b/src/main/java/com/backend/farmon/service/PostService/PostQueryService.java
@@ -7,4 +7,5 @@ public interface PostQueryService {
 
     // 홈 화면 카테고리에 따른 커뮤니티 게시글 3개씩 조회
     HomeResponse.PostListDTO findHomePostsByCategory(PostType category);
+
 }

--- a/src/main/java/com/backend/farmon/service/PostService/PostQueryService.java
+++ b/src/main/java/com/backend/farmon/service/PostService/PostQueryService.java
@@ -7,4 +7,7 @@ public interface PostQueryService {
 
     // 홈 화면 카테고리에 따른 커뮤니티 게시글 3개씩 조회
     HomeResponse.PostListDTO findHomePostsByCategory(PostType category);
+
+    // 인기 전문가 칼럼 6개 조회
+    HomeResponse.PopularPostListDTO findPopularExpertColumnPosts();
 }

--- a/src/main/java/com/backend/farmon/service/PostService/PostQueryService.java
+++ b/src/main/java/com/backend/farmon/service/PostService/PostQueryService.java
@@ -7,5 +7,4 @@ public interface PostQueryService {
 
     // 홈 화면 카테고리에 따른 커뮤니티 게시글 3개씩 조회
     HomeResponse.PostListDTO findHomePostsByCategory(PostType category);
-
 }

--- a/src/main/java/com/backend/farmon/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/PostService/PostQueryServiceImpl.java
@@ -52,4 +52,18 @@ public class PostQueryServiceImpl implements PostQueryService {
 
         return HomeConverter.toPostListDTO(postList, likeCountList, commentCountList);
     }
+
+    // 인기 전문가 칼럼 6개 조회
+    @Override
+    public HomeResponse.PopularPostListDTO findPopularExpertColumnPosts() {
+        // 별도로 인기 칼럼으로 지정할 지정할 전문가 칼럼 게시글 아이디 리스트
+        List<Long> popularPostsIdList = new ArrayList<>();
+        popularPostsIdList.add(4L);
+
+        // 인기 전문가 칼럼 6개 조회
+        List<Post> expertColumnPostList = postRepository.findTop6ExpertColumnPostsByPostId(popularPostsIdList);
+        log.info("홈 화면 인기 전문가 칼럼 조회 성공");
+
+        return HomeConverter.toPopularPostListDTO(expertColumnPostList);
+    }
 }

--- a/src/main/java/com/backend/farmon/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/PostService/PostQueryServiceImpl.java
@@ -35,33 +35,24 @@ public class PostQueryServiceImpl implements PostQueryService {
     // 홈 화면 카테고리에 따른 커뮤니티 게시글 3개씩 조회
     // 인기, 전체, QNA, 전문가 칼럼
     @Override
-    public HomeResponse.PostListDTO findHomePostsByCategory(Long userId, PostType category) {
-        if(userId!=null){
-            User user = userRepository.findById(userId)
-                    .orElseThrow(()-> new UserHandler(ErrorStatus.USER_NOT_FOUND));
-
-            if(!userAuthorizationUtil.getCurrentUserId().equals(userId)){
-                log.error("userId 불일치, 로그인 userId: {}, 파라미터 userId: {}", userAuthorizationUtil.getCurrentUserId(), userId);
-                // 에러 던지기
-            }
-        }
+    public HomeResponse.PostListDTO findHomePostsByCategory(PostType category) {
 
         // 카테고리별 게시글 조회
         PostFetchStrategy strategy = strategyFactory.getStrategy(category);
         List<Post> postList = strategy.fetchPosts(category);
-        log.info("홈 화면 카테고리별 게시글 조회 성공, userId: {}", userId);
+        log.info("홈 화면 카테고리별 게시글 조회 성공");
 
         // 각 게시물의 좋아요 개수 조회
         List<Integer> likeCountList = postList.stream()
                 .map(post -> likeCountRepository.countLikeCountsByPostId(post.getId()))
                 .toList();
-        log.info("홈 화면 카테고리별 게시글 좋아요 개수 조회 성공, userId: {}", userId);
+        log.info("홈 화면 카테고리별 게시글 좋아요 개수 조회 성공");
 
         // 각 게시물의 댓글 개수 조회
         List<Integer> commentCountList = postList.stream()
                 .map(post -> commentRepository.countCommentsByPostId(post.getId()))
                 .toList();
-        log.info("홈 화면 카테고리별 게시글 댓글 개수 조회 성공, userId: {}", userId);
+        log.info("홈 화면 카테고리별 게시글 댓글 개수 조회 성공");
 
         return HomeConverter.toPostListDTO(postList, likeCountList, commentCountList);
     }

--- a/src/main/java/com/backend/farmon/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/PostService/PostQueryServiceImpl.java
@@ -1,16 +1,12 @@
 package com.backend.farmon.service.PostService;
 
-import com.backend.farmon.apiPayload.code.status.ErrorStatus;
-import com.backend.farmon.apiPayload.exception.handler.UserHandler;
-import com.backend.farmon.config.security.UserAuthorizationUtil;
 import com.backend.farmon.converter.HomeConverter;
 import com.backend.farmon.domain.Post;
-import com.backend.farmon.domain.User;
 import com.backend.farmon.dto.home.HomeResponse;
 import com.backend.farmon.dto.post.PostType;
 import com.backend.farmon.repository.CommentRepository.CommentRepository;
 import com.backend.farmon.repository.LikeCountRepository.LikeCountRepository;
-import com.backend.farmon.repository.UserRepository.UserRepository;
+import com.backend.farmon.repository.PostRepository.PostRepository;
 import com.backend.farmon.strategy.postType.PostFetchStrategy;
 import com.backend.farmon.strategy.postType.PostFetchStrategyFactory;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -29,8 +26,7 @@ public class PostQueryServiceImpl implements PostQueryService {
     private final PostFetchStrategyFactory strategyFactory;
     private final CommentRepository commentRepository;
     private final LikeCountRepository likeCountRepository;
-    private final UserRepository userRepository;
-    private final UserAuthorizationUtil userAuthorizationUtil;
+    private final PostRepository postRepository;
 
     // 홈 화면 카테고리에 따른 커뮤니티 게시글 3개씩 조회
     // 인기, 전체, QNA, 전문가 칼럼

--- a/src/main/java/com/backend/farmon/service/PostService/PostQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/PostService/PostQueryServiceImpl.java
@@ -48,7 +48,7 @@ public class PostQueryServiceImpl implements PostQueryService {
 
         // 카테고리별 게시글 조회
         PostFetchStrategy strategy = strategyFactory.getStrategy(category);
-        List<Post> postList = strategy.fetchPosts();
+        List<Post> postList = strategy.fetchPosts(category);
         log.info("홈 화면 카테고리별 게시글 조회 성공, userId: {}", userId);
 
         // 각 게시물의 좋아요 개수 조회

--- a/src/main/java/com/backend/farmon/service/UserService/UserQueryService.java
+++ b/src/main/java/com/backend/farmon/service/UserService/UserQueryService.java
@@ -6,5 +6,5 @@ import com.backend.farmon.dto.user.ExchangeResponse;
 public interface UserQueryService {
 
     // 농업인 - 전문가 전환
-    ExchangeResponse exchangeRole(Long userId, Role role);
+    ExchangeResponse exchangeRole(Long userId, Role role, String existingToken);
 }

--- a/src/main/java/com/backend/farmon/service/UserService/UserQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/UserService/UserQueryServiceImpl.java
@@ -3,6 +3,8 @@ package com.backend.farmon.service.UserService;
 import com.backend.farmon.apiPayload.code.status.ErrorStatus;
 import com.backend.farmon.apiPayload.exception.handler.ExpertHandler;
 import com.backend.farmon.apiPayload.exception.handler.UserHandler;
+import com.backend.farmon.config.security.JWTUtil;
+import com.backend.farmon.config.security.UserAuthorizationUtil;
 import com.backend.farmon.converter.UserConverter;
 import com.backend.farmon.domain.Expert;
 import com.backend.farmon.domain.User;
@@ -12,8 +14,15 @@ import com.backend.farmon.repository.ExpertReposiotry.ExpertRepository;
 import com.backend.farmon.repository.UserRepository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,9 +31,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserQueryServiceImpl implements UserQueryService {
     private final UserRepository userRepository;
     private final ExpertRepository expertRepository;
+    private final JWTUtil jwtUtil;
+    private final UserAuthorizationUtil userAuthorizationUtill;
 
     @Override
-    public ExchangeResponse exchangeRole(Long userId, Role role) {
+    public ExchangeResponse exchangeRole(Long userId, Role role, String existingToken) {
+        // 역할 전환 시 현재 역할과 중복되지 않은지 검사
+        String currentRole = userAuthorizationUtill.getCurrentUserRole();
+        if(currentRole.equals(role.toString()))
+            throw new AuthenticationCredentialsNotFoundException(
+                    "전환하려는 역할과 현재 로그인한 역할이 일치합니다. 현재 역할: " + currentRole
+            );
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
@@ -34,8 +52,26 @@ public class UserQueryServiceImpl implements UserQueryService {
                 .orElseThrow(() -> new ExpertHandler(ErrorStatus.EXPERT_NOT_REGISTER))
                 : null;
 
-        // jwt 사용 시 별도의 로직 필요?
+        // 농업인 - 전문가 전환을 위해 역할이 변경된 새로운 토큰을 생성
+        String newToken = jwtUtil.updateRoleInToken(existingToken, role.toString());
 
-        return UserConverter.toExchangeResponse(userId, role, expert);
+        // 토큰에서 새 역할 추출
+        String updatedRole = jwtUtil.extractRole(newToken);
+
+        // 인증정보 업데이트
+        Authentication updatedAuthentication = new UsernamePasswordAuthenticationToken(
+                jwtUtil.extractUserId(newToken), // User ID
+                null,                            // 자격증명 (패스워드 등)
+                Collections.singletonList(new SimpleGrantedAuthority(updatedRole)) // 새 역할
+        );
+
+        // SecurityContext에 새 인증정보 설정
+        SecurityContextHolder.getContext().setAuthentication(updatedAuthentication);
+
+        log.info("농업인 - 전문가 전환 새 토큰 발급 완료");
+        log.info("새로 전환된 역할: {}, userId: {}",
+                userAuthorizationUtill.getCurrentUserRole(), userAuthorizationUtill.getCurrentUserId());
+
+        return UserConverter.toExchangeResponse(userId, updatedRole, expert, newToken);
     }
 }

--- a/src/main/java/com/backend/farmon/strategy/postType/CategoryPostFetchStrategy.java
+++ b/src/main/java/com/backend/farmon/strategy/postType/CategoryPostFetchStrategy.java
@@ -9,17 +9,15 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-// 전체 게시글 3개씩 조회
+// Q&A, 전문가 칼럼 게시글 3개씩 조회
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class AllPostFetchStrategy implements PostFetchStrategy {
-
+public class CategoryPostFetchStrategy implements PostFetchStrategy{
     private final PostRepository postRepository;
-
     @Override
     public List<Post> fetchPosts(PostType postType) {
         log.info("홈 화면 {} 게시글 조회", postType.name());
-        return postRepository.findTop3Posts();
+        return postRepository.findTop3PostsByPostTYpe(postType);
     }
 }

--- a/src/main/java/com/backend/farmon/strategy/postType/PopularPostFetchStrategy.java
+++ b/src/main/java/com/backend/farmon/strategy/postType/PopularPostFetchStrategy.java
@@ -1,6 +1,7 @@
 package com.backend.farmon.strategy.postType;
 
 import com.backend.farmon.domain.Post;
+import com.backend.farmon.dto.post.PostType;
 import com.backend.farmon.repository.PostRepository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,8 +18,8 @@ public class PopularPostFetchStrategy implements PostFetchStrategy {
     private final PostRepository postRepository;
 
     @Override
-    public List<Post> fetchPosts() {
-        log.info("홈 화면 <인기> 게시글 조회");
+    public List<Post> fetchPosts(PostType postType) {
+        log.info("홈 화면 {} 게시글 조회", postType.name());
         return postRepository.findTop3PostsByLikes();
     }
 }

--- a/src/main/java/com/backend/farmon/strategy/postType/PostFetchStrategy.java
+++ b/src/main/java/com/backend/farmon/strategy/postType/PostFetchStrategy.java
@@ -1,9 +1,10 @@
 package com.backend.farmon.strategy.postType;
 
 import com.backend.farmon.domain.Post;
+import com.backend.farmon.dto.post.PostType;
 
 import java.util.List;
 
 public interface PostFetchStrategy {
-    List<Post> fetchPosts();
+    List<Post> fetchPosts(PostType postType);
 }

--- a/src/main/java/com/backend/farmon/strategy/postType/PostFetchStrategyFactory.java
+++ b/src/main/java/com/backend/farmon/strategy/postType/PostFetchStrategyFactory.java
@@ -1,8 +1,11 @@
 package com.backend.farmon.strategy.postType;
 
+import com.backend.farmon.apiPayload.exception.handler.PostTypeHandler;
 import com.backend.farmon.dto.post.PostType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import static com.backend.farmon.apiPayload.code.status.ErrorStatus.POST_TYPE_NOT_FOUND;
 
 // 카테고리에 따라 적절한 전략을 반환하는 팩토리 클래스
 @RequiredArgsConstructor
@@ -11,6 +14,7 @@ public class PostFetchStrategyFactory {
 
     private final PopularPostFetchStrategy popularPostFetchStrategy;
     private final AllPostFetchStrategy allPostFetchStrategy;
+    private final CategoryPostFetchStrategy categoryPostFetchStrategy;
 
     public PostFetchStrategy getStrategy(PostType category) {
         switch (category) {
@@ -18,8 +22,10 @@ public class PostFetchStrategyFactory {
                 return popularPostFetchStrategy;
             case ALL:
                 return allPostFetchStrategy;
+            case QNA, EXPERT_COLUMN, EXPERT_LOUNGE:
+                return categoryPostFetchStrategy;
             default:
-                throw new IllegalArgumentException("Unsupported category: " + category);
+                throw new PostTypeHandler(POST_TYPE_NOT_FOUND);
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #57 

## 📝작업 내용
홈화면에서 인기 전문가 칼럼 게시글 6개 조회하는 부분을 추가하였습니다.
인기 전문가 칼럼으로 별도로 지정할 게시글들(관련 게시글들의 아이디를 리스트로 받음)이 먼저 조회되고, 그 다음은 좋아요 순으로 조회되도록 구현하였습니다.

컨버터에서 게시글 이미지나 전문가 프로필 이미지를 가져오는 부분은 간단하게 getter를 이용하였는데, 쿼리수가 너무 많아져서 지금처럼 그대로 getter로 구현할 지, 별도의 쿼리 작성이 필요할 지 조금 헷갈립니다.
<img width="534" alt="image" src="https://github.com/user-attachments/assets/3ef512fe-2b32-42be-bba6-0c87247de99c" />


## 💬리뷰 요구사항(선택)

> 피드백 있으면 편하게 말씀해주세요!