### PR TITLE
✨[Feat] 채팅방 컨설팅 완료 구현

### DIFF
--- a/src/main/java/com/backend/farmon/controller/ChatRoomController.java
+++ b/src/main/java/com/backend/farmon/controller/ChatRoomController.java
@@ -136,7 +136,7 @@ public class ChatRoomController {
     })
     @GetMapping("/room")
     public ApiResponse<ChatResponse.ChatRoomDataDTO> getChatRoomData (@RequestParam(name = "userId") @EqualsUserId  Long userId,
-                                                                      @RequestParam(name = "chatRoomId") Long chatRoomId) {
+                                                                          @RequestParam(name = "chatRoomId") Long chatRoomId) {
         ChatResponse.ChatRoomDataDTO response = chatRoomQueryService.findChatRoomDataAndChangeUnreadMessage(userId, chatRoomId);
 
         return ApiResponse.onSuccess(response);
@@ -222,4 +222,28 @@ public class ChatRoomController {
         return ApiResponse.onSuccess(response);
     }
 
+    // 채팅방 컨설팅 완료
+    @Operation(
+            summary = "채팅방 컨설팅 완료",
+            description = "채팅방에서 현재 로그인한 사용자가 컨설팅 완료를 진행하는 API 입니다." +
+                    "유저 아이디, 채팅방 아이디를 쿼리 스트링으로 입력해주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTHORIZATION_4031", description = "인증된 사용자 정보와 요청된 리소스의 사용자 정보가 다릅니다. (userId 불일치)", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHATROOM4001", description = "채팅방 아이디와 일치하는 채팅방이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
+            @Parameter(name = "chatRoomId", description = "채팅방의 아이디", example = "1", required = true)
+    })
+    @PatchMapping("/room/complete")
+    public ApiResponse<ChatResponse.ChatRoomCompleteDTO> patchChatRoomUserComplete (@RequestParam(name = "userId") @EqualsUserId  Long userId,
+                                                                                    @RequestParam(name = "chatRoomId") Long chatRoomId) {
+        ChatResponse.ChatRoomCompleteDTO response = chatRoomCommandService.exchangeChatRoomUserComplete(userId, chatRoomId);
+
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/com/backend/farmon/controller/ChatRoomController.java
+++ b/src/main/java/com/backend/farmon/controller/ChatRoomController.java
@@ -60,10 +60,10 @@ public class ChatRoomController {
     }
 
 
-    // 이름과 일치하는 채팅 목록 조회
+    // 이름, 작물 이름과 일치하는 채팅 목록 조회
     @Operation(
-            summary = "채팅 상대 이름으로 검색하여 일치하는 상대방과의 채팅 목록 조회 API",
-            description = "채팅 상대방의 이름을 검색하여 일치하는 상대방과의 채팅 목록을 조회하는 API이며, 페이징을 포함합니다. " +
+            summary = "채팅 상대 이름 혹은 작물 이름으로 검색하여 일치하는 채팅 목록 조회 API",
+            description = "채팅 상대 이름 혹은 작물 이름으로 검색하여 일치하는 채팅 목록 조회하는 API이며, 페이징을 포함합니다. " +
                     "유저 아이디, 읽음 여부 필터, 검색할 채팅 상대 이름, 페이지 번호를 쿼리 스트링으로 입력해주세요."
     )
     @ApiResponses({
@@ -76,44 +76,14 @@ public class ChatRoomController {
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
             @Parameter(name = "read", description = "읽음 여부 필터링. 안 읽은 채팅방만 필터링 시에는 false, 이외에는 true 입니다.", example = "false", required = true),
-            @Parameter(name = "name", description = "검색할 채팅 상대방의 이름입니다.", example = "김팜온", required = true),
+            @Parameter(name = "searchName", description = "검색어", example = "김팜온", required = true),
             @Parameter(name = "page", description = "페이지 번호, 1부터 시작입니다.", example = "1", required = true)
     })
-    @GetMapping("/rooms/name")
-    public ApiResponse<ChatResponse.ChatRoomListDTO> getChatRoomPageByExpertName (@RequestParam(name = "userId") @EqualsUserId Long userId,
-                                                                                  @RequestParam(name = "read") String read,
-                                                                                  @RequestParam(name = "expertName") String expertName,
-                                                                                  @CheckPage Integer page) {
-        ChatResponse.ChatRoomListDTO response = ChatResponse.ChatRoomListDTO.builder().build();
-
-        return ApiResponse.onSuccess(response);
-    }
-
-
-    // 작물 이름으로 검색하여 일치하는 전문가와의 채팅 목록 조회
-    @Operation(
-            summary = "작물 이름으로 검색하여 일치하는 전문가와의 채팅 목록 조회",
-            description = "작물 이름으로 검색하여 일치하는 해당 분야의 전문가와의 채팅 목록을 조회하는 API이며 페이징을 포함합니다. " +
-                    "유저 아이디, 읽음 여부 필터, 검색할 전문가의 작물 이름, 페이지 번호를 쿼리 스트링으로 입력해주세요."
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTHORIZATION_4031", description = "인증된 사용자 정보와 요청된 리소스의 사용자 정보가 다릅니다. (userId 불일치)", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAGE4001", description = "페이지 번호는 1 이상이어야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-    })
-    @Parameters({
-            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
-            @Parameter(name = "read", description = "읽음 여부 필터링. 안 읽은 채팅방만 필터링 시에는 false, 이외에는 true 입니다.", example = "1", required = true),
-            @Parameter(name = "cropsName", description = "검색할 전문가의 작물 이름(쌀, 곡물 등)입니다.", example = "쌀", required = true),
-            @Parameter(name = "page", description = "페이지 번호, 1부터 시작입니다.", example = "1", required = true)
-    })
-    @GetMapping("/rooms/crops")
-    public ApiResponse<ChatResponse.ChatRoomListDTO> getChatRoomPageByCropsName (@RequestParam(name = "userId") @EqualsUserId Long userId,
-                                                                                 @RequestParam(name = "read") String read,
-                                                                                 @RequestParam(name = "cropsName") String cropsName,
-                                                                                 @CheckPage Integer page) {
+    @GetMapping("/rooms/all/search")
+    public ApiResponse<ChatResponse.ChatRoomListDTO> getChatRoomPageBySearch(@RequestParam(name = "userId") @EqualsUserId Long userId,
+                                                                             @RequestParam(name = "read") String read,
+                                                                             @RequestParam(name = "searchName") String searchName,
+                                                                             @CheckPage Integer page) {
         ChatResponse.ChatRoomListDTO response = ChatResponse.ChatRoomListDTO.builder().build();
 
         return ApiResponse.onSuccess(response);
@@ -147,10 +117,10 @@ public class ChatRoomController {
     }
 
 
-    // 채팅방 입장
+    // 채팅 대화 상대의 정보 조회
     @Operation(
-            summary = "채팅방 아이디와 일치하는 채팅방 입장",
-            description = "채팅방 아이디와 일치하는 채팅방 입장에 입장하여 유저의 채팅방 접속 시간을 기록하고, 채팅 대화 상대의 정보를 가져오는 API 입니다. " +
+            summary = " 채팅방의 정보 조회",
+            description = "채팅방 아이디와 일치하는 채팅방 입장에 입장하여 채팅 대화 상대의 정보와 컨설팅 완료 정보를 가져오는 API 입니다. " +
                     "유저 아이디, 채팅방 아이디를 쿼리 스트링으로 입력해주세요."
     )
     @ApiResponses({
@@ -164,17 +134,17 @@ public class ChatRoomController {
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
             @Parameter(name = "chatRoomId", description = "입장하려는 채팅방의 아이디", example = "1", required = true),
     })
-    @PatchMapping("/room")
-    public ApiResponse<ChatResponse.ChatRoomEnterDTO> enterChatRoom (@RequestParam(name = "userId") @EqualsUserId  Long userId,
-                                                                       @RequestParam(name = "chatRoomId") Long chatRoomId) {
-        ChatResponse.ChatRoomEnterDTO response = chatRoomCommandService.updateLastEnterTime(userId, chatRoomId);
+    @GetMapping("/room")
+    public ApiResponse<ChatResponse.ChatRoomDataDTO> getChatRoomData (@RequestParam(name = "userId") @EqualsUserId  Long userId,
+                                                                      @RequestParam(name = "chatRoomId") Long chatRoomId) {
+        ChatResponse.ChatRoomDataDTO response = chatRoomQueryService.findChatRoomDataAndChangeUnreadMessage(userId, chatRoomId);
 
         return ApiResponse.onSuccess(response);
     }
 
     // 채팅 메시지 내역 조회
     @Operation(
-            summary = "채팅방 아이디이와 일치하는 채팅방의 대화 내역 조회",
+            summary = "채팅방의 대화 내역 조회",
             description = "채팅방 아이디와 일치하는 채팅방의 채팅 대화 내역을 무한스크롤로 받는 API 입니다. " +
                     "유저 아이디, 채팅방 아이디, 페이지 번호를 쿼리 스트링으로 입력해주세요."
     )
@@ -191,7 +161,7 @@ public class ChatRoomController {
             @Parameter(name = "chatRoomId", description = "대화 내역(메시지)을 조회하려는 채팅방의 아이디", example = "1", required = true),
             @Parameter(name = "page", description = "페이지 번호, 1부터 시작입니다.", example = "1", required = true)
     })
-    @GetMapping("/room")
+    @GetMapping("/room/message")
     public ApiResponse<ChatResponse.ChatMessageListDTO> getChatMessageList (@RequestParam(name = "userId") @EqualsUserId Long userId,
                                                                             @RequestParam(name = "chatRoomId") Long chatRoomId,
                                                                             @CheckPage Integer page) {

--- a/src/main/java/com/backend/farmon/converter/ChatConverter.java
+++ b/src/main/java/com/backend/farmon/converter/ChatConverter.java
@@ -24,7 +24,6 @@ public class ChatConverter {
                 .name(chatRoom.getFarmer().getUserName())
 //                .profileImage(chatRoom.getFarmer().getProfileImageUrl())
                 .type("농업인")
-                .averageResponseTime(farmer.getChatAverageResponseTime())
                 .build();
     }
 
@@ -34,25 +33,32 @@ public class ChatConverter {
                 .build();
     }
 
-    public static ChatResponse.ChatRoomEnterDTO toChatRoomEnterDTO(ChatRoom chatRoom, String userType) {
+    public static ChatResponse.ChatRoomDataDTO toChatRoomDataDTO(ChatRoom chatRoom, String userType) {
         boolean isExpert = userType.equals("전문가");
 
+        // 내가 전문가
         if (isExpert) {
-            return ChatResponse.ChatRoomEnterDTO.builder()
+            return ChatResponse.ChatRoomDataDTO.builder()
                     .name(chatRoom.getFarmer().getUserName())
 //                    .profileImage(chatRoom.getFarmer().getProfileImageUrl())
                     .type("농업인")
                     .lastEnterTime(ConvertTime.convertLocalDatetimeToTime(chatRoom.getFarmerLastEnter()))
                     .averageResponseTime(chatRoom.getFarmer().getChatAverageResponseTime())
+                    .isComplete(chatRoom.getIsExpertComplete())
+                    .isOtherComplete(chatRoom.getIsFarmerComplete())
+                    .isEstimateComplete(chatRoom.getEstimate().getStatus().equals(1))
                     .build();
         }
 
-        return ChatResponse.ChatRoomEnterDTO.builder()
+        return ChatResponse.ChatRoomDataDTO.builder()
                 .name(chatRoom.getExpert().getUser().getUserName())
 //                .profileImage(chatRoom.getExpert().getUser().getProfileImageUrl())
                 .type("전문가")
                 .lastEnterTime(ConvertTime.convertLocalDatetimeToTime(chatRoom.getExpertLastEnter()))
                 .averageResponseTime(chatRoom.getExpert().getUser().getChatAverageResponseTime())
+                .isComplete(chatRoom.getIsFarmerComplete())
+                .isOtherComplete(chatRoom.getIsExpertComplete())
+                .isEstimateComplete(chatRoom.getEstimate().getStatus().equals(1))
                 .build();
     }
 

--- a/src/main/java/com/backend/farmon/converter/ChatConverter.java
+++ b/src/main/java/com/backend/farmon/converter/ChatConverter.java
@@ -112,7 +112,7 @@ public class ChatConverter {
                 .estimateBudget(chatRoom.getEstimate().getBudget())
                 .estimateCategory(chatRoom.getEstimate().getCategory())
                 .estimateAreaName(area.getAreaName())
-                .estimateAreaName(area.getAreaNameDetail())
+                .estimateAreaDetail(area.getAreaNameDetail())
                 .unreadMessageCount(unReadMessageCount)
                 .lastMessageContent(chatMessage != null ? chatMessage.getContent() : null) // null-safe 처리
                 .lastMessageDate(chatMessage != null ? ConvertTime.convertToYearMonthDay(chatMessage.getCreatedAt()) : null) // null-safe 처리

--- a/src/main/java/com/backend/farmon/converter/ChatConverter.java
+++ b/src/main/java/com/backend/farmon/converter/ChatConverter.java
@@ -140,4 +140,12 @@ public class ChatConverter {
                 )
                 .build();
     }
+
+    public static ChatResponse.ChatRoomCompleteDTO toChatRoomCompleteDTO(ChatRoom chatRoom, Boolean isOtherComplete, Boolean isEstimateComplete) {
+        return ChatResponse.ChatRoomCompleteDTO.builder()
+                .isOtherComplete(isOtherComplete)
+                .isComplete(true)
+                .isEstimateComplete(isEstimateComplete)
+                .build();
+    }
 }

--- a/src/main/java/com/backend/farmon/domain/enums/ChatMessageType.java
+++ b/src/main/java/com/backend/farmon/domain/enums/ChatMessageType.java
@@ -2,6 +2,6 @@ package com.backend.farmon.domain.enums;
 
 // 채팅 메시지 타입
 public enum ChatMessageType {
-    // 텍스트, 이미지, 거래 완료, 퇴장
-    TEXT, IMAGE, COMPLETE, EXIT
+    // 텍스트, 이미지, 퇴장
+    TEXT, IMAGE, EXIT
 }

--- a/src/main/java/com/backend/farmon/dto/chat/ChatResponse.java
+++ b/src/main/java/com/backend/farmon/dto/chat/ChatResponse.java
@@ -208,4 +208,21 @@ public class ChatResponse {
         @Schema(description = "견적 이미지 리스트")
         List<String> estimateImageList;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "채팅방 컨설팅 완료 정보")
+    public static class ChatRoomCompleteDTO {
+        @Schema(description = "사용자의 컨설팅 완료 여부", example = "true")
+        Boolean isComplete;
+
+        @Schema(description = "채팅 상대의 컨설팅 완료 여부", example = "true")
+        Boolean isOtherComplete;
+
+        @Schema(description = "견적 완료 여부, 농업인 전문가 모두 컨설팅 완료 시 true", example = "true")
+        Boolean isEstimateComplete;
+    }
 }

--- a/src/main/java/com/backend/farmon/dto/chat/ChatResponse.java
+++ b/src/main/java/com/backend/farmon/dto/chat/ChatResponse.java
@@ -128,9 +128,6 @@ public class ChatResponse {
 
         @Schema(description = "채팅 상대 역할, 농업인 또는 전문가", example = "농업인")
         String type;
-
-        @Schema(description = "채팅 상대의 평균 메시지 응답 시간, 정보가 없는 사용자이면 null", example = "1시간")
-        String averageResponseTime;
     }
 
     @Getter
@@ -138,8 +135,8 @@ public class ChatResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    @Schema(description = "채팅방 입장 성공")
-    public static class ChatRoomEnterDTO {
+    @Schema(description = "채팅방 정보")
+    public static class ChatRoomDataDTO {
 
         @Schema(description = "채팅 중인 상대방 이름", example = "김팜온")
         String name;
@@ -155,6 +152,15 @@ public class ChatResponse {
 
         @Schema(description = "채팅 상대의 평균 메시지 응답 시간, 정보가 없는 사용자이면 null", example = "1시간")
         String averageResponseTime;
+
+        @Schema(description = "채팅 상대의 컨설팅 완료 여부", example = "true")
+        Boolean isOtherComplete;
+
+        @Schema(description = "사용자의 컨설팅 완료 여부", example = "true")
+        Boolean isComplete;
+
+        @Schema(description = "견적 완료 여부, 농업인 전문가 모두 컨설팅 완료 시 true", example = "true")
+        Boolean isEstimateComplete;
     }
 
     @Getter

--- a/src/main/java/com/backend/farmon/repository/ChatMessageRepository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/com/backend/farmon/repository/ChatMessageRepository/ChatMessageRepositoryImpl.java
@@ -25,7 +25,7 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryCustom {
         List<ChatMessage> content = queryFactory.selectFrom(chatMessage)
                 .where(
                         chatMessage.chatRoom.id.eq(chatRoomId),
-                        chatMessage.type.notIn(ChatMessageType.EXIT, ChatMessageType.COMPLETE)
+                        chatMessage.type.notIn(ChatMessageType.EXIT)
                 )
                 .orderBy(chatMessage.createdAt.desc())
                 .offset(pageable.getOffset())

--- a/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryCustom.java
@@ -6,8 +6,8 @@ import org.springframework.data.domain.Pageable;
 
 public interface ChatRoomRepositoryCustom {
     // userId와 연관된 채팅방 페이징 조회
-    Page<ChatRoom> findChatRoomsByUserId(Long userId, Pageable pageable);
+    Page<ChatRoom> findChatRoomsByUserIdAndRole(Long userId, String role, Pageable pageable);
 
     // userId와 연관된 채팅방 중 안 읽음 메시지가 존재하는 채팅방만 페이징 조회
-    Page<ChatRoom> findUnReadChatRoomsByUserId(Long userId, Pageable pageable);
+    Page<ChatRoom> findUnReadChatRoomsByUserIdAndRole(Long userId, String role, Pageable pageable);
 }

--- a/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryImpl.java
@@ -21,9 +21,18 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
 
     // userId와 연관된 채팅방 페이징 조회
     @Override
-    public Page<ChatRoom> findChatRoomsByUserId(Long userId, Pageable pageable) {
+    public Page<ChatRoom> findChatRoomsByUserIdAndRole(Long userId, String role, Pageable pageable) {
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(chatRoom.farmer.id.eq(userId).or(chatRoom.expert.user.id.eq(userId)));
+
+        // role에 따른 조건 추가
+        if ("FARMER".equalsIgnoreCase(role)) {
+            builder.and(chatRoom.farmer.id.eq(userId));
+        } else if ("EXPERT".equalsIgnoreCase(role)) {
+            builder.and(chatRoom.expert.user.id.eq(userId));
+        } else {
+            throw new IllegalArgumentException("Invalid role: " + role);
+        }
 
         // 데이터 조회 쿼리
         QueryResults<ChatRoom> results = queryFactory
@@ -40,9 +49,18 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
 
     // userId와 연관된 채팅방 중 안 읽음 메시지가 존재하는 채팅방만 페이징 조회
     @Override
-    public Page<ChatRoom> findUnReadChatRoomsByUserId(Long userId, Pageable pageable) {
+    public Page<ChatRoom> findUnReadChatRoomsByUserIdAndRole(Long userId, String role, Pageable pageable) {
         BooleanBuilder builder = new BooleanBuilder();
-        builder.and(chatRoom.farmer.id.eq(userId).or(chatRoom.expert.user.id.eq(userId)));
+
+        // role에 따른 조건 추가
+        if ("FARMER".equalsIgnoreCase(role)) {
+            builder.and(chatRoom.farmer.id.eq(userId));
+        } else if ("EXPERT".equalsIgnoreCase(role)) {
+            builder.and(chatRoom.expert.user.id.eq(userId));
+        } else {
+            throw new IllegalArgumentException("Invalid role: " + role);
+        }
+
         builder.and(chatMessage.isRead.isFalse());
 
         // 데이터 조회 쿼리

--- a/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomCommandService.java
+++ b/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomCommandService.java
@@ -9,4 +9,7 @@ public interface ChatRoomCommandService {
 
     // 채팅방 삭제
     ChatResponse.ChatRoomDeleteDTO removeChatRoom(Long userId, Long chatRoomId);
+
+    // 채팅방 컨설팅 완료
+    ChatResponse.ChatRoomCompleteDTO exchangeChatRoomUserComplete(Long userId, Long chatRoomId);
 }

--- a/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomCommandService.java
+++ b/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomCommandService.java
@@ -7,9 +7,6 @@ public interface ChatRoomCommandService {
     // 채팅방 생성
     ChatResponse.ChatRoomCreateDTO addChatRoom(Long userId, Long estimateId);
 
-    // 채팅방 입장
-    ChatResponse.ChatRoomEnterDTO updateLastEnterTime(Long userId, Long chatRoomId);
-
     // 채팅방 삭제
     ChatResponse.ChatRoomDeleteDTO removeChatRoom(Long userId, Long chatRoomId);
 }

--- a/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomCommandServiceImpl.java
@@ -59,34 +59,6 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService{
         return ChatConverter.toChatRoomCreateDTO(chatRoom, farmer);
     }
 
-    // 채팅방 입장
-    @Transactional
-    @Override
-    public ChatResponse.ChatRoomEnterDTO updateLastEnterTime(Long userId, Long chatRoomId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
-
-        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-                .orElseThrow(() -> new ChatRoomHandler(ErrorStatus.CHATROOM_NOT_FOUND));
-
-        boolean isExpert = chatRoom.getExpert().getId().equals(userId);
-        LocalDateTime now = LocalDateTime.now();
-
-        // 마지막 채팅방 접속 시간 변경
-        if (isExpert) {
-            chatRoom.setExpertLastEnter(now);
-        } else {
-            chatRoom.setFarmerLastEnter(now);
-        }
-
-        // 안 읽은 메시지들을 읽음 처리
-        chatMessageRepository.updateMessagesToReadByChatRoomId(chatRoomId, userId);
-        log.info("안 읽은 메시지들 읽음 처리 완료 - 채팅방 아아디: {}", chatRoomId);
-
-        String userType = isExpert ? "전문가" : "농업인";
-        return ChatConverter.toChatRoomEnterDTO(chatRoom, userType);
-    }
-
     // 채팅방 삭제
     @Transactional
     @Override

--- a/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomCommandServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomCommandServiceImpl.java
@@ -87,9 +87,7 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService{
         // 채팅방에서의 전문가 여부
         boolean isExpert = chatRoom.getExpert().getId().equals(userId);
 
-
         boolean isOtherComplete = false;
-
         // 컨설팅 완료 여부 변경 및 상대 거래 완료 여부 조회
         if(isExpert){
             chatRoom.setIsExpertComplete(true);
@@ -108,6 +106,8 @@ public class ChatRoomCommandServiceImpl implements ChatRoomCommandService{
             estimate.setStatus(1);
             isEstimateComplete = true;
         }
+
+        log.info("채팅방 컨설팅 완료 - 유저 아이디: {}, 채팅방 아아디: {}", userId, chatRoomId);
 
         return ChatConverter.toChatRoomCompleteDTO(chatRoom, isOtherComplete, isEstimateComplete);
     }

--- a/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryService.java
+++ b/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryService.java
@@ -6,6 +6,9 @@ public interface ChatRoomQueryService {
     // 채팅방 목록 조회
     ChatResponse.ChatRoomListDTO findChatRoom(Long userId, Integer read, Integer pageNumber);
 
+    // 채팅방 정보 조회 & 안 읽음 메시지 읽음 처리
+    ChatResponse.ChatRoomDataDTO findChatRoomDataAndChangeUnreadMessage(Long userId, Long chatRoomId);
+
     // 채팅방의 견적 조회
     ChatResponse.ChatRoomEstimateDTO findChatRoomEstimate(Long userId, Long chatRoomId);
 }

--- a/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryServiceImpl.java
@@ -4,6 +4,7 @@ import com.backend.farmon.apiPayload.code.status.ErrorStatus;
 import com.backend.farmon.apiPayload.exception.handler.ChatRoomHandler;
 import com.backend.farmon.apiPayload.exception.handler.EstimateHandler;
 import com.backend.farmon.apiPayload.exception.handler.UserHandler;
+import com.backend.farmon.config.security.UserAuthorizationUtil;
 import com.backend.farmon.converter.ChatConverter;
 import com.backend.farmon.domain.*;
 import com.backend.farmon.dto.chat.ChatResponse;
@@ -31,6 +32,7 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
     private final ChatMessageRepository chatMessageRepository;
     private final UserRepository userRepository;
     private final EstimateRepository estimateRepository;
+    private final UserAuthorizationUtil userAuthorizationUtil;
 
     private static final Integer PAGE_SIZE=10;
 
@@ -45,10 +47,13 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
+        // 현재 로그인한 사용자의 역할
+        String role = userAuthorizationUtil.getCurrentUserRole();
+
         // 안 읽음 필터링에 따른 유저의 모든 채팅방 목록을 페이지네이션으로 조회
         Page<ChatRoom> chatRoomPage = read.equals(1)
-                ? chatRoomRepository.findUnReadChatRoomsByUserId(userId, pageRequest(pageNumber))
-                : chatRoomRepository.findChatRoomsByUserId(userId, pageRequest(pageNumber));
+                ? chatRoomRepository.findUnReadChatRoomsByUserIdAndRole(userId, role, pageRequest(pageNumber))
+                : chatRoomRepository.findChatRoomsByUserIdAndRole(userId, role, pageRequest(pageNumber));
 
         log.info("안 읽음 필터링에 따른 유저의 모든 채팅방 목록 페이지네이션 조회 완료 - userId: {}", userId);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #97 

## 📝작업 내용
기존에는 컨설팅 완료를 농업인과 전문가가 메시지를 주고 받는 TYPE으로 구현하려고 하였으나,
rest api로 구현하는 것이 더 적합하다고 생각해 채팅방 - 컨설팅 완료 API 설계 및 구현으로 변경하였습니다.
채팅방에서 사용자의 역할이 농업인이라면 `ChatRoom` 엔티티에서 농업인 거래 완료 여부가 true로 변경되고, 전문가라면 전문가 거래 완료 여부가 true로 변경됩니다.
농업인, 전문가 모두 컨설팅 완료 시 `Estimate`의 status가 1로 변경됩니다.

### 스크린샷 (선택)
<img width="850" alt="image" src="https://github.com/user-attachments/assets/04750691-0a1b-47b1-9f01-d4835f4a79c0" />
