### PR TITLE
✨[Feat] 채팅방 목록 조회 검색어 필터링 추가, 홈 화면 API 명세서 수정

### DIFF
--- a/src/main/java/com/backend/farmon/controller/ChatRoomController.java
+++ b/src/main/java/com/backend/farmon/controller/ChatRoomController.java
@@ -49,14 +49,14 @@ public class ChatRoomController {
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
             @Parameter(name = "read", description = "읽음 여부 필터링. 안 읽은 채팅방만 필터링 시에는 1, 이외에는 0 입니다.", example = "0", required = true),
+            @Parameter(name = "page", description = "페이지 번호, 1부터 시작입니다.", example = "1", required = true),
             @Parameter(name = "searchName", description = "검색어", example = "병해중전문가"),
-            @Parameter(name = "page", description = "페이지 번호, 1부터 시작입니다.", example = "1", required = true)
     })
     @GetMapping("/rooms/all")
     public ApiResponse<ChatResponse.ChatRoomListDTO> getChatRoomPage (@RequestParam(name = "userId") @EqualsUserId Long userId,
                                                                       @RequestParam(name = "read") Integer read,
-                                                                      @RequestParam(name = "searchName", required = false) String searchName,
-                                                                      @CheckPage Integer page){
+                                                                      @CheckPage Integer page,
+                                                                      @RequestParam(name = "searchName", required = false) String searchName){
 
         ChatResponse.ChatRoomListDTO response = chatRoomQueryService.findChatRoomBySearch(userId, read, searchName, page);
 

--- a/src/main/java/com/backend/farmon/controller/ChatRoomController.java
+++ b/src/main/java/com/backend/farmon/controller/ChatRoomController.java
@@ -35,7 +35,9 @@ public class ChatRoomController {
     @Operation(
             summary = "사용자의 전체 채팅 목록 조회 API",
             description = "사용자의 전체 채팅 목록을 조회하는 API이며, 페이징을 포함합니다. " +
-                    "유저 아이디, 읽음 여부 필터, 페이지 번호를 쿼리 스트링으로 입력해주세요."
+                    "채팅 상대 이름 혹은 작물 이름으로 검색하는 경우에는 검색어를 쿼리 스트링에 입력해 주세요. " +
+                    "검색어를 입력하지 않은 경우에는 전체 채팅 목록을 조회합니다. " +
+                    "유저 아이디, 읽음 여부 필터, 검색어, 페이지 번호를 쿼리 스트링으로 입력해주세요."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
@@ -47,44 +49,16 @@ public class ChatRoomController {
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
             @Parameter(name = "read", description = "읽음 여부 필터링. 안 읽은 채팅방만 필터링 시에는 1, 이외에는 0 입니다.", example = "0", required = true),
+            @Parameter(name = "searchName", description = "검색어", example = "병해중전문가"),
             @Parameter(name = "page", description = "페이지 번호, 1부터 시작입니다.", example = "1", required = true)
     })
     @GetMapping("/rooms/all")
     public ApiResponse<ChatResponse.ChatRoomListDTO> getChatRoomPage (@RequestParam(name = "userId") @EqualsUserId Long userId,
                                                                       @RequestParam(name = "read") Integer read,
+                                                                      @RequestParam(name = "searchName", required = false) String searchName,
                                                                       @CheckPage Integer page){
 
-        ChatResponse.ChatRoomListDTO response = chatRoomQueryService.findChatRoom(userId, read, page);
-
-        return ApiResponse.onSuccess(response);
-    }
-
-
-    // 이름, 작물 이름과 일치하는 채팅 목록 조회
-    @Operation(
-            summary = "채팅 상대 이름 혹은 작물 이름으로 검색하여 일치하는 채팅 목록 조회 API",
-            description = "채팅 상대 이름 혹은 작물 이름으로 검색하여 일치하는 채팅 목록 조회하는 API이며, 페이징을 포함합니다. " +
-                    "유저 아이디, 읽음 여부 필터, 검색할 채팅 상대 이름, 페이지 번호를 쿼리 스트링으로 입력해주세요."
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTHORIZATION_4031", description = "인증된 사용자 정보와 요청된 리소스의 사용자 정보가 다릅니다. (userId 불일치)", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAGE4001", description = "페이지 번호는 1 이상이어야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-    })
-    @Parameters({
-            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
-            @Parameter(name = "read", description = "읽음 여부 필터링. 안 읽은 채팅방만 필터링 시에는 false, 이외에는 true 입니다.", example = "false", required = true),
-            @Parameter(name = "searchName", description = "검색어", example = "김팜온", required = true),
-            @Parameter(name = "page", description = "페이지 번호, 1부터 시작입니다.", example = "1", required = true)
-    })
-    @GetMapping("/rooms/all/search")
-    public ApiResponse<ChatResponse.ChatRoomListDTO> getChatRoomPageBySearch(@RequestParam(name = "userId") @EqualsUserId Long userId,
-                                                                             @RequestParam(name = "read") String read,
-                                                                             @RequestParam(name = "searchName") String searchName,
-                                                                             @CheckPage Integer page) {
-        ChatResponse.ChatRoomListDTO response = ChatResponse.ChatRoomListDTO.builder().build();
+        ChatResponse.ChatRoomListDTO response = chatRoomQueryService.findChatRoomBySearch(userId, read, searchName, page);
 
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -27,7 +27,8 @@ public class HomeController {
     @Operation(
             summary = "홈 화면 커뮤니티 게시글 조회 API",
             description = "홈 화면에서 커뮤니티 카테고리에 따른 게시글을 조회합니다. " +
-                    "필터링 할 커뮤니티 카테고리 이름을 쿼리 스트링으로 입력해 주세요. "
+                    "필터링 할 커뮤니티 카테고리 이름을 쿼리 스트링으로 입력해 주세요. " +
+                    "로그인한 사용자의 경우 발급받은 토큰을 헤더에 입려해주세요. 로그인하지 않은 사용자의 경우에는 토큰을 입력하지 않아도 됩니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
@@ -47,7 +48,8 @@ public class HomeController {
     // 홈 화면 - 인기 칼럼 조회
     @Operation(
             summary = "홈 화면 인기 칼럼 조회 API",
-            description = "홈 화면에서 인기 칼럼 게시글 목록을 6개 조회합니다."
+            description = "홈 화면에서 인기 칼럼 게시글 목록을 6개 조회합니다." +
+            "로그인한 사용자의 경우 발급받은 토큰을 헤더에 입려해주세요. 로그인하지 않은 사용자의 경우에는 토큰을 입력하지 않아도 됩니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
@@ -60,10 +62,53 @@ public class HomeController {
     }
 
 
+    // 홈 화면 검색 - 자동 완성
+    @Operation(
+            summary = "홈 화면 검색어 목록 조회 API",
+            description = "홈 화면 검색어 입력 시 사용자가 입력한 검색어와 관련된 작물 이름들을 반환합니다. " +
+                    "유저 아이디와 검색어를 쿼리 스트링으로 입력해 주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
+            @Parameter(name = "searchName", description = "검색어", example = "1"),
+    })
+    @GetMapping("/search")
+    public ApiResponse<HomeResponse.AutoCompleteSearchDTO> getHomeAutoCompleteSearchNameList (@RequestParam(name = "userId", required = false) Long userId,
+                                                                                              @RequestParam(name = "searchName") String searchName){
+        HomeResponse.AutoCompleteSearchDTO response = HomeResponse.AutoCompleteSearchDTO.builder().build();;
+        return ApiResponse.onSuccess(response);
+    }
+
+
+    // 홈 화면 검색 - 자동 완성 저장
+    @Operation(
+            summary = "홈 화면 검색어 저장 API",
+            description = "홈 화면 검색어 입력 시 사용자가 입력한 검색어와 관련된 작물 이름들이 반환되었을 때 " +
+                    "반환된 작물 이름들 중 사용자가 원하는 작물을 클릭하면 해당 작물 이름을 저장합니다. " +
+                    "유저 아이디와 저장할 작물 이름을 쿼리 스트링으로 입력해 주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
+            @Parameter(name = "searchName", description = "저장할 작물 이름", example = "1"),
+    })
+    @PostMapping("/search")
+    public ApiResponse<HomeResponse.AutoCompleteSearchDTO> postHomeAutoCompleteSearchNameList (@RequestParam(name = "userId", required = false) Long userId,
+                                                                                               @RequestParam(name = "searchName") String searchName){
+        HomeResponse.AutoCompleteSearchDTO response = HomeResponse.AutoCompleteSearchDTO.builder().build();;
+        return ApiResponse.onSuccess(response);
+    }
+
+
     // 최근 검색어 조회
     @Operation(
             summary = "홈 화면 최근 검색어 조회 API",
-            description = "홈 화면 검색 창에서 사용자의 최근 검색어들을 조회합니다. 로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
+            description = "홈 화면 검색 창에서 사용자의 최근 검색어들을 조회합니다. 유저 아이디를 쿼리 스트링으로 입력해 주세요."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
@@ -71,39 +116,18 @@ public class HomeController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
-            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1")
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1")
     })
     @GetMapping("/search/recent")
-    public ApiResponse<HomeResponse.RecentSearchListDTO> getRecentSearches (@RequestParam(name = "userId", required = false) Long userId){
+    public ApiResponse<HomeResponse.RecentSearchListDTO> getRecentSearches (@RequestParam(name = "userId") Long userId){
         HomeResponse.RecentSearchListDTO response = HomeResponse.RecentSearchListDTO.builder().build();;
         return ApiResponse.onSuccess(response);
     }
 
-
-    // 추천 검색어 조회
-    @Operation(
-            summary = "홈 화면 추천 검색어 조회 API",
-            description = "홈 화면 검색 창에서 추천 검색어들을 조회합니다.  로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-    })
-    @Parameters({
-            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1")
-    })
-    @GetMapping("/search/recommend")
-    public ApiResponse<HomeResponse.RecommendSearchListDTO> getRecommendSearches (@RequestParam(name = "userId", required = false) Long userId){
-        HomeResponse.RecommendSearchListDTO response = HomeResponse.RecommendSearchListDTO.builder().build();;
-        return ApiResponse.onSuccess(response);
-    }
-
-
     // 특정 검색어 삭제 API
     @Operation(
-            summary = "홈 화면에서 특정 검색어 삭제 API",
-            description = "홈 화면에서 특정 검색어를 삭제하는 API 입니다. 유저 아이디와 삭제할 검색어 이름을 쿼리 스트링으로 입력해 주세요."
+            summary = "홈 화면에서 최근 검색어에서 특정 검색어 삭제 API",
+            description = "홈 화면에서 최근 검색어 목록에서 특정 검색어를 삭제하는 API 입니다. 유저 아이디와 삭제할 검색어 이름을 쿼리 스트링으로 입력해 주세요."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
@@ -114,10 +138,10 @@ public class HomeController {
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
             @Parameter(name = "name", description = "삭제 할 검색어 이름", example = "병충해 관리")
     })
-    @DeleteMapping("/search")
+    @DeleteMapping("/search/recent")
     public ApiResponse<HomeResponse.SearchDeleteDTO> deleteSearchName(@RequestParam(name = "userId") Long userId,
-                                                                  @RequestParam(name = "name") String searchName){
-        HomeResponse.SearchDeleteDTO response = HomeResponse.SearchDeleteDTO.builder().build();;
+                                                                      @RequestParam(name = "name") String searchName){
+        HomeResponse.SearchDeleteDTO response = HomeResponse.SearchDeleteDTO.builder().build();
         return ApiResponse.onSuccess(response);
     }
 
@@ -135,27 +159,30 @@ public class HomeController {
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1")
     })
-    @DeleteMapping("/search/all")
+    @DeleteMapping("/search/recent/all")
     public ApiResponse<HomeResponse.SearchDeleteDTO> deleteAllSearchName(@RequestParam(name = "userId") Long userId) {
         HomeResponse.SearchDeleteDTO response = HomeResponse.SearchDeleteDTO.builder().build();;
         return ApiResponse.onSuccess(response);
     }
 
-    // 홈 화면 검색 - 자동 완성
-//    @Operation(
-//            summary = "홈 화면 조회 API",
-//            description = "홈 화면 로딩에 필요한 정보를 조회합니다. 로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
-//    )
-//    @ApiResponses({
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
-//    })
-//    @Parameters({
-//            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1"),
-//    })
-//    @GetMapping("/search")
-//    public ApiResponse<HomeResponse.HomePageDTO> getChatRoomPage (@RequestParam(name = "userId", required = false) Long userId,
-//                                                                  @RequestParam(name = "category") String category){
-//        HomeResponse.HomePageDTO response = HomeResponse.HomePageDTO.builder().build();;
-//        return ApiResponse.onSuccess(response);
-//    }
+    // 추천 검색어 조회
+    @Operation(
+            summary = "홈 화면 추천 검색어 조회 API",
+            description = "홈 화면 검색 창에서 추천 검색어들을 조회합니다. 유저 아이디를 쿼리 스트링으로 입력해 주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1")
+    })
+    @GetMapping("/search/recommend")
+    public ApiResponse<HomeResponse.RecommendSearchListDTO> getRecommendSearches (@RequestParam(name = "userId") Long userId){
+        HomeResponse.RecommendSearchListDTO response = HomeResponse.RecommendSearchListDTO.builder().build();;
+        return ApiResponse.onSuccess(response);
+    }
+
+
 }

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -98,9 +98,9 @@ public class HomeController {
             @Parameter(name = "searchName", description = "저장할 작물 이름", example = "1"),
     })
     @PostMapping("/search")
-    public ApiResponse<HomeResponse.AutoCompleteSearchDTO> postHomeAutoCompleteSearchNameList (@RequestParam(name = "userId", required = false) Long userId,
+    public ApiResponse<HomeResponse.AutoCompleteSearchPostDTO> postHomeAutoCompleteSearchNameList (@RequestParam(name = "userId", required = false) Long userId,
                                                                                                @RequestParam(name = "searchName") String searchName){
-        HomeResponse.AutoCompleteSearchDTO response = HomeResponse.AutoCompleteSearchDTO.builder().build();;
+        HomeResponse.AutoCompleteSearchPostDTO response = HomeResponse.AutoCompleteSearchPostDTO.builder().build();;
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/backend/farmon/converter/ChatConverter.java
+++ b/src/main/java/com/backend/farmon/converter/ChatConverter.java
@@ -111,23 +111,24 @@ public class ChatConverter {
     }
 
     public static ChatResponse.ChatRoomDetailDTO toChatRoomDetailDTO(
-            ChatRoom chatRoom, ChatMessage chatMessage, Area area, Boolean isExpert, Integer unReadMessageCount) {
+            ChatRoom chatRoom, ChatMessage chatMessage, Area area, Boolean isExpert, Long unReadMessageCount) {
 
+        // 내가 전문가라면 농업인을 user로 가져오기
         User user = isExpert
-                ? chatRoom.getExpert().getUser()
-                : chatRoom.getFarmer();
+                ? chatRoom.getFarmer()
+                : chatRoom.getExpert().getUser();
 
         return ChatResponse.ChatRoomDetailDTO.builder()
                 .chatRoomId(chatRoom.getId())
                 .name(user.getUserName())
-                .profileImage(isExpert && user.getExpert() != null && user.getExpert().getProfileImageUrl() != null
+                .profileImage(!isExpert && user.getExpert() != null && user.getExpert().getProfileImageUrl() != null
                         ? user.getExpert().getProfileImageUrl()
                         : null)
                 .estimateBudget(chatRoom.getEstimate().getBudget())
                 .estimateCategory(chatRoom.getEstimate().getCategory())
                 .estimateAreaName(area.getAreaName())
                 .estimateAreaDetail(area.getAreaNameDetail())
-                .unreadMessageCount(unReadMessageCount)
+                .unreadMessageCount(unReadMessageCount.intValue())
                 .lastMessageContent(chatMessage != null ? chatMessage.getContent() : null) // null-safe 처리
                 .lastMessageDate(chatMessage != null ? ConvertTime.convertToYearMonthDay(chatMessage.getCreatedAt()) : null) // null-safe 처리
                 .build();

--- a/src/main/java/com/backend/farmon/converter/ChatConverter.java
+++ b/src/main/java/com/backend/farmon/converter/ChatConverter.java
@@ -62,6 +62,10 @@ public class ChatConverter {
 
         return ChatResponse.ChatRoomDataDTO.builder()
                 .name(chatRoom.getExpert().getUser().getUserName())
+                .nickName(chatRoom.getExpert().getNickName() != null
+                        ? chatRoom.getExpert().getNickName()
+                        : null)
+                .isExpertNickNameOnly(chatRoom.getExpert().getIsNickNameOnly())
                 .profileImage(chatRoom.getExpert().getProfileImageUrl() != null
                         ? chatRoom.getExpert().getProfileImageUrl()
                         : null)
@@ -121,6 +125,9 @@ public class ChatConverter {
         return ChatResponse.ChatRoomDetailDTO.builder()
                 .chatRoomId(chatRoom.getId())
                 .name(user.getUserName())
+                .nickName(!isExpert ? user.getExpert().getNickName() : null) // 내가 전문가가 아니면(내가 농업인) 상대는 전문가
+                .isExpertNickNameOnly(!isExpert ? user.getExpert().getIsNickNameOnly() : null)
+                .type(isExpert ? "농업인" : "전문가") // 내가 전문가이면 상대 타입은 농업인
                 .profileImage(!isExpert && user.getExpert() != null && user.getExpert().getProfileImageUrl() != null
                         ? user.getExpert().getProfileImageUrl()
                         : null)

--- a/src/main/java/com/backend/farmon/dto/chat/ChatRequest.java
+++ b/src/main/java/com/backend/farmon/dto/chat/ChatRequest.java
@@ -40,7 +40,7 @@ public class ChatRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    @Schema(description = "전송 또는 수신할 채팅 메시지 정보")
+    @Schema(description = "전송 또는 수신할 채팅 메시지 정보(테스트용)")
     public static class TestDTO {
 
         @Schema(description = "보낸 사람 아이디, 현재 로그인한 사용자의 userId와 동일", example = "1")

--- a/src/main/java/com/backend/farmon/dto/chat/ChatResponse.java
+++ b/src/main/java/com/backend/farmon/dto/chat/ChatResponse.java
@@ -45,6 +45,15 @@ public class ChatResponse {
         @Schema(description = "채팅 중인 상대방 이름", example = "김팜온")
         String name;
 
+        @Schema(description = "채팅 중인 상대방 닉네임 (채팅 상대가 전문가일 경우에만 해당) / 채팅 상대가 농업인이면 null", example = "병해충전문가")
+        String nickName;
+
+        @Schema(description = "채팅 중인 상대가 전문가일 경우, 닉네임만 보이게 활성화 여부 / 채팅 상대가 농업인이면 null", example = "true")
+        Boolean isExpertNickNameOnly;
+
+        @Schema(description = "채팅 상대 역할, 농업인 또는 전문가", example = "농업인")
+        String type;
+
         @Schema(description = "채팅 중인 상대방 프로필 이미지")
         String profileImage;
 
@@ -140,6 +149,12 @@ public class ChatResponse {
 
         @Schema(description = "채팅 중인 상대방 이름", example = "김팜온")
         String name;
+
+        @Schema(description = "채팅 중인 상대방 닉네임 (채팅 상대가 전문가일 경우에만 해당)", example = "병해충전문가")
+        String nickName;
+
+        @Schema(description = "채팅 중인 상대가 전문가일 경우, 닉네임만 보이게 활성화 여부", example = "true")
+        Boolean isExpertNickNameOnly;
 
         @Schema(description = "채팅 중인 상대방 프로필 이미지")
         String profileImage;

--- a/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
+++ b/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
@@ -118,4 +118,29 @@ public class HomeResponse {
         @Schema(description = "검색어 삭제 성공 여부", example = "true")
         Boolean isSearchDelete;
     }
+
+    @ToString
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "홈 페이지 자동 완성 검색어 정보")
+    public static class AutoCompleteSearchDTO  {
+
+        @Schema(description = "추천 검색어 리스트")
+        List <String> searchList;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "홈 페이지 자동 완성 검색어 저장 반환 정보")
+    public static class AutoCompleteSearchPostDTO {
+
+        @Schema(description = "검색어 저장 여부", example = "true")
+        Boolean isSearchSave;
+    }
 }

--- a/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
+++ b/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
@@ -128,7 +128,7 @@ public class HomeResponse {
     @Schema(description = "홈 페이지 자동 완성 검색어 정보")
     public static class AutoCompleteSearchDTO  {
 
-        @Schema(description = "추천 검색어 리스트")
+        @Schema(description = "자동 완성 검색어 리스트")
         List <String> searchList;
     }
 

--- a/src/main/java/com/backend/farmon/repository/ChatMessageRepository/ChatMessageRepository.java
+++ b/src/main/java/com/backend/farmon/repository/ChatMessageRepository/ChatMessageRepository.java
@@ -16,8 +16,11 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>,
     @Query("SELECT cm FROM ChatMessage cm WHERE cm.chatRoom.id = :chatRoomId AND cm.type IN :types ORDER BY cm.createdAt DESC")
     Optional<ChatMessage> findLatestMessageByTypes(@Param("chatRoomId") Long chatRoomId, @Param("types") List<ChatMessageType> types);
 
-    // 채팅방 아이디와 일치하면서 isRead가 false인 메시지 리스트 조회
-    List<ChatMessage> findByChatRoomIdAndIsReadFalse(Long chatRoomId);
+    // 채팅방 아이디와 일치하면서 isRead가 false인 메시지 개수 조회
+    long countByChatRoomIdAndIsReadFalseAndTypeIn(Long chatRoomId, List<ChatMessageType> types);
+
+//    @Query("SELECT COUNT(cm) FROM ChatMessage cm WHERE cm.chatRoom.id = :chatRoomId AND cm.isRead = false AND cm.type IN :types")
+//    long countUnreadMessagesByChatRoomIdAndTypes(@Param("chatRoomId") Long chatRoomId, @Param("types") List<ChatMessageType> types);
 
     // 채팅방 아이디와 일치하는 채팅 메시지들 삭제
     @Modifying

--- a/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryCustom.java
@@ -5,9 +5,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ChatRoomRepositoryCustom {
-    // userId와 연관된 채팅방 페이징 조회
-    Page<ChatRoom> findChatRoomsByUserIdAndRole(Long userId, String role, Pageable pageable);
+    // userId와 연관된 검색어와 일치하는 채팅방 페이징 조회
+    Page<ChatRoom> findChatRoomsByUserIdAndRoleAndSearch(Long userId, String role, String searchName, Pageable pageable);
 
-    // userId와 연관된 채팅방 중 안 읽음 메시지가 존재하는 채팅방만 페이징 조회
-    Page<ChatRoom> findUnReadChatRoomsByUserIdAndRole(Long userId, String role, Pageable pageable);
+    // userId와 연관된 검색어와 일치하는 채팅방 중 안 읽음 메시지가 존재하는 채팅방만 페이징 조회
+    Page<ChatRoom> findUnReadChatRoomsByUserIdAndRoleAndSearch(Long userId, String role, String searchName, Pageable pageable);
 }

--- a/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryImpl.java
@@ -20,10 +20,11 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
     QChatRoom chatRoom = QChatRoom.chatRoom;
     QChatMessage chatMessage = QChatMessage.chatMessage;
 
-    // userId와 연관된 채팅방 페이징 조회
     @Override
-    public Page<ChatRoom> findChatRoomsByUserIdAndRole(Long userId, String role, Pageable pageable) {
+    public Page<ChatRoom> findChatRoomsByUserIdAndRoleAndSearch(Long userId, String role, String searchName, Pageable pageable) {
         BooleanBuilder builder = new BooleanBuilder();
+
+        // userId와 연관된 채팅방 조회
         builder.and(chatRoom.farmer.id.eq(userId).or(chatRoom.expert.user.id.eq(userId)));
 
         // role에 따른 조건 추가
@@ -37,6 +38,16 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
 
         // 텍스트, 이미지 메시지만 조회
         builder.and(chatMessage.type.in(ChatMessageType.TEXT, ChatMessageType.IMAGE));
+
+        // 검색어 조건 (세 가지 중 하나라도 포함되면 조회)
+        if (searchName != null && !searchName.trim().isEmpty()) {
+            BooleanBuilder searchCondition = new BooleanBuilder();
+            searchCondition.or(chatRoom.farmer.userName.containsIgnoreCase(searchName)); // 농업인 사용자명 검색
+            searchCondition.or(chatRoom.expert.nickName.containsIgnoreCase(searchName)); // 전문가 닉네임 검색
+            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(true).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시할 경우, 원래 사용자명도 검색
+
+            builder.and(searchCondition); // 전체 조건에 추가
+        }
 
         // 데이터 조회 쿼리
         QueryResults<ChatRoom> results = queryFactory
@@ -54,7 +65,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
 
     // userId와 연관된 채팅방 중 안 읽음 메시지가 존재하는 채팅방만 페이징 조회
     @Override
-    public Page<ChatRoom> findUnReadChatRoomsByUserIdAndRole(Long userId, String role, Pageable pageable) {
+    public Page<ChatRoom> findUnReadChatRoomsByUserIdAndRoleAndSearch(Long userId, String role, String searchName, Pageable pageable) {
         BooleanBuilder builder = new BooleanBuilder();
 
         // role에 따른 조건 추가
@@ -69,6 +80,16 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
         // 안 읽은 텍스트, 이미지 메시지만 조회
         builder.and(chatMessage.isRead.isFalse());
         builder.and(chatMessage.type.in(ChatMessageType.TEXT, ChatMessageType.IMAGE));
+
+        // 검색어 조건 (세 가지 중 하나라도 포함되면 조회)
+        if (searchName != null && !searchName.trim().isEmpty()) {
+            BooleanBuilder searchCondition = new BooleanBuilder();
+            searchCondition.or(chatRoom.farmer.userName.containsIgnoreCase(searchName)); // 농업인 사용자명 검색
+            searchCondition.or(chatRoom.expert.nickName.containsIgnoreCase(searchName)); // 전문가 닉네임 검색
+            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(true).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시할 경우, 원래 사용자명도 검색
+
+            builder.and(searchCondition); // 전체 조건에 추가
+        }
 
         // 데이터 조회 쿼리
         QueryResults<ChatRoom> results = queryFactory

--- a/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryImpl.java
@@ -39,12 +39,15 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
         // 텍스트, 이미지 메시지만 조회
         builder.and(chatMessage.type.in(ChatMessageType.TEXT, ChatMessageType.IMAGE));
 
-        // 검색어 조건 (세 가지 중 하나라도 포함되면 조회)
+        // 검색어 조건 (여섯 가지 중 하나라도 포함되면 조회)
         if (searchName != null && !searchName.trim().isEmpty()) {
             BooleanBuilder searchCondition = new BooleanBuilder();
             searchCondition.or(chatRoom.farmer.userName.containsIgnoreCase(searchName)); // 농업인 사용자명 검색
             searchCondition.or(chatRoom.expert.nickName.containsIgnoreCase(searchName)); // 전문가 닉네임 검색
-            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(true).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시할 경우, 원래 사용자명도 검색
+            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(false).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시하지 않을 경우, 원래 사용자명도 검색
+            searchCondition.or(chatRoom.estimate.crop.category.containsIgnoreCase(searchName)); // 작물 카테고리로 검색
+            searchCondition.or(chatRoom.estimate.crop.name.containsIgnoreCase(searchName)); // 작물 디테일 이름으로 검색
+            searchCondition.or(chatRoom.estimate.category.containsIgnoreCase(searchName)); // 견적 분야로 검색
 
             builder.and(searchCondition); // 전체 조건에 추가
         }
@@ -81,12 +84,15 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
         builder.and(chatMessage.isRead.isFalse());
         builder.and(chatMessage.type.in(ChatMessageType.TEXT, ChatMessageType.IMAGE));
 
-        // 검색어 조건 (세 가지 중 하나라도 포함되면 조회)
+        // 검색어 조건 (여섯 가지 중 하나라도 포함되면 조회)
         if (searchName != null && !searchName.trim().isEmpty()) {
             BooleanBuilder searchCondition = new BooleanBuilder();
             searchCondition.or(chatRoom.farmer.userName.containsIgnoreCase(searchName)); // 농업인 사용자명 검색
             searchCondition.or(chatRoom.expert.nickName.containsIgnoreCase(searchName)); // 전문가 닉네임 검색
-            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(true).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시할 경우, 원래 사용자명도 검색
+            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(false).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시하지 않을 경우, 원래 사용자명도 검색
+            searchCondition.or(chatRoom.estimate.crop.category.containsIgnoreCase(searchName)); // 작물 카테고리로 검색
+            searchCondition.or(chatRoom.estimate.crop.name.containsIgnoreCase(searchName)); // 작물 디테일 이름으로 검색
+            searchCondition.or(chatRoom.estimate.category.containsIgnoreCase(searchName)); // 견적 분야로 검색
 
             builder.and(searchCondition); // 전체 조건에 추가
         }

--- a/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryService.java
+++ b/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryService.java
@@ -3,8 +3,8 @@ package com.backend.farmon.service.ChatRoomService;
 import com.backend.farmon.dto.chat.ChatResponse;
 
 public interface ChatRoomQueryService {
-    // 채팅방 목록 조회
-    ChatResponse.ChatRoomListDTO findChatRoom(Long userId, Integer read, Integer pageNumber);
+    // 검색어 별 채팅방 목록 조회
+    ChatResponse.ChatRoomListDTO findChatRoomBySearch(Long userId, Integer read, String searchName, Integer pageNumber);
 
     // 채팅방 정보 조회 & 안 읽음 메시지 읽음 처리
     ChatResponse.ChatRoomDataDTO findChatRoomDataAndChangeUnreadMessage(Long userId, Long chatRoomId);


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #107 
> - #20 


## 📝작업 내용
- 기존에는 채팅방 목록 조회 시 로그인 한 사용자의 역할과 일치하는 채팅방만 조회하였는데 **검색어 필터링 조건**(유저 이름, 전문가일 경우 닉네임, 견적 작물 카테고리, 견적 작물 이름, 견적 서비스 이름)을 추가하여 사용자가 검색어를 입력하면, 해당 검색어와 필터링 조건에 일치하는 채팅방 목록을 반환하도록 하였습니다. **검색어가 없다면, 사용자의 전체 채팅방 목록을 반환**합니다.
- 채팅 상대가 전문가일 경우, 닉네임과 닉네임만 보이기 활성화 여부 필드도 반환하도록 추가하였습니다. 해당 필드들은 채팅 상대가 전문가일 경우에만 반환되고, 채팅 상대가 농업인일 경우에는 null을 반환하도록 구현하였습니다.
  
  <img width="652" alt="image" src="https://github.com/user-attachments/assets/95cf4b6d-302a-49a0-abe6-c6f7d9d53c03" />

- 홈 화면 검색 관련 api 명세서 수정이 필요하여 수정하였습니다.

### 스크린샷 (선택)
<img width="853" alt="image" src="https://github.com/user-attachments/assets/6ece5fd2-45c6-4c9a-9d50-6c95729130eb" />
<img width="863" alt="image" src="https://github.com/user-attachments/assets/dc62d7a8-379d-45ab-95d0-8f79d0b02678" />


## 💬리뷰 요구사항(선택)

> 전문가일 경우에만 가지는 조건이 너무 많아서, 상대가 농업인일 경우에는 null 값을 반환하는 경우가 많아진 것 같습니다.. 각각의 경우마다 dto를 따로 만들기에는 너무 복잡해질 것 같아 일단 관련된 값이 없는 경우에는 null을 반환하도록 하였는데 프론트에서 구현하기 불편하다고 하시면 수정하도록 하겠습니다!

> 피드백 편하게 주세요!