### PR TITLE
✨[Feat] 홈 화면 최근 검색어 저장, 조회, 삭제 구현

### DIFF
--- a/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
@@ -13,7 +13,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 가장 일반적인 응답
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
-    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","해당 경로는 인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     // 유저 관려 에러

--- a/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
@@ -67,7 +67,10 @@ public enum ErrorStatus implements BaseErrorCode {
     EXPERT_DETAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "EXPERT_DETAIL4001", "해당 추가정보 아이디와 일치하는 추가정보가 존재하지 않습니다."),
 
     // 채팅 메시지 타입
-    MESSAGE_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "MESSAGE_TYPE4001", "지원되지 않는 채팅 메시지 타입입니다.");
+    MESSAGE_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "MESSAGE_TYPE4001", "지원되지 않는 채팅 메시지 타입입니다."),
+
+    // 검색어 관련 에러
+    SEARCH_NOT_EMPTY(HttpStatus.BAD_REQUEST, "SEARCH_4001", "검색어가 비어 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/backend/farmon/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/backend/farmon/apiPayload/exception/ExceptionAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,16 +43,22 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
         Map<String, String> errors = new LinkedHashMap<>();
 
-        e.getBindingResult().getFieldErrors().stream()
-                .forEach(fieldError -> {
-                    String fieldName = fieldError.getField();
-                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
-                    errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
-                });
+        e.getBindingResult().getFieldErrors().forEach(fieldError -> {
+            String fieldName = fieldError.getField();
+            String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+            errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+        });
 
         return handleExceptionInternalArgs(e,HttpHeaders.EMPTY,ErrorStatus.valueOf("_BAD_REQUEST"),request,errors);
     }
 
+    // ✅ 401 UNAUTHORIZED - 인증 오류 추가
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<Object> handleAuthenticationException(AuthenticationException e, WebRequest request) {
+        log.warn("401 Unauthorized Error: {}", e.getMessage());
+
+        return handleExceptionInternalUnauthorized(e, ErrorStatus._UNAUTHORIZED, HttpHeaders.EMPTY, request);
+    }
 
     // 500 INTERNAL_SERVER_ERROR
     @ExceptionHandler
@@ -62,7 +69,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(value = GeneralException.class)
-    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+    public ResponseEntity<Object> onThrowException(GeneralException generalException, HttpServletRequest request) {
 
         ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
 
@@ -86,7 +93,6 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
     private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
                                                                 HttpHeaders headers, HttpStatus status, WebRequest request, String errorPoint) {
-        // false(isSuccess), code, message, data
         ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorPoint);
         return super.handleExceptionInternal(
                 e,
@@ -99,7 +105,6 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
     private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorCommonStatus,
                                                                WebRequest request, Map<String, String> errorArgs) {
-        // false(isSuccess), code, message, data
         ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(),errorCommonStatus.getMessage(),errorArgs);
         return super.handleExceptionInternal(
                 e,
@@ -118,6 +123,19 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
                 body,
                 headers,
                 errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    // ✅ 401 UNAUTHORIZED 처리
+    private ResponseEntity<Object> handleExceptionInternalUnauthorized(Exception e, ErrorStatus errorCommonStatus,
+                                                                       HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                HttpStatus.UNAUTHORIZED,
                 request
         );
     }

--- a/src/main/java/com/backend/farmon/apiPayload/exception/handler/SearchHandler.java
+++ b/src/main/java/com/backend/farmon/apiPayload/exception/handler/SearchHandler.java
@@ -1,0 +1,11 @@
+package com.backend.farmon.apiPayload.exception.handler;
+
+import com.backend.farmon.apiPayload.code.BaseErrorCode;
+import com.backend.farmon.apiPayload.exception.GeneralException;
+
+public class SearchHandler extends GeneralException {
+    public SearchHandler(BaseErrorCode code) {
+        super(code);
+    }
+
+}

--- a/src/main/java/com/backend/farmon/config/RedisConfig.java
+++ b/src/main/java/com/backend/farmon/config/RedisConfig.java
@@ -9,6 +9,7 @@ import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.*;
 
 @Configuration
@@ -24,6 +25,20 @@ public class RedisConfig {
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration(host, port);
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    // 사용자 최근 검색어 저장
+    @Bean
+    @Primary
+    public RedisTemplate<String, String> recentSeachLogRedisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+
+        return redisTemplate;
     }
 
     //레디스 캐시

--- a/src/main/java/com/backend/farmon/config/security/JWTAuthenticationFilter.java
+++ b/src/main/java/com/backend/farmon/config/security/JWTAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.backend.farmon.config.security;
 
+import com.backend.farmon.apiPayload.code.status.ErrorStatus;
+import com.backend.farmon.apiPayload.exception.handler.AuthorizationHandler;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -51,6 +53,9 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
             }
         } catch (Exception e) {
             logger.error("Invalid JWT token: " + e.getMessage());
+
+            // 토큰이 없을 경우 에러 던짐
+            throw new AuthorizationHandler(ErrorStatus._UNAUTHORIZED);
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/backend/farmon/config/security/UserAuthorizationUtil.java
+++ b/src/main/java/com/backend/farmon/config/security/UserAuthorizationUtil.java
@@ -1,13 +1,18 @@
 package com.backend.farmon.config.security;
 
+import com.backend.farmon.apiPayload.code.status.ErrorStatus;
+import com.backend.farmon.apiPayload.exception.handler.AuthorizationHandler;
+import com.backend.farmon.apiPayload.exception.handler.UserHandler;
 import com.backend.farmon.repository.UserRepository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class UserAuthorizationUtil {
@@ -43,11 +48,18 @@ public class UserAuthorizationUtil {
     public boolean isCurrentUserIdMatching(Long userId) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authentication == null || authentication.getPrincipal() == null) {
-            throw new AuthenticationCredentialsNotFoundException("Authentication or principal is null");
+        if (authentication == null || authentication.getPrincipal() == null ||
+                "anonymousUser".equals(authentication.getPrincipal())) {
+            throw new AuthorizationHandler(ErrorStatus._UNAUTHORIZED);
         }
 
-        Long currentUserId = (Long) authentication.getPrincipal();
+        Object principal = authentication.getPrincipal();
+
+        if (!(principal instanceof Long)) {
+            throw new AuthorizationHandler(ErrorStatus._UNAUTHORIZED);
+        }
+
+        Long currentUserId = (Long) principal;
         return currentUserId.equals(userId);
     }
 

--- a/src/main/java/com/backend/farmon/controller/ChatRoomController.java
+++ b/src/main/java/com/backend/farmon/controller/ChatRoomController.java
@@ -49,14 +49,14 @@ public class ChatRoomController {
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
             @Parameter(name = "read", description = "읽음 여부 필터링. 안 읽은 채팅방만 필터링 시에는 1, 이외에는 0 입니다.", example = "0", required = true),
+            @Parameter(name = "page", description = "페이지 번호, 1부터 시작입니다.", example = "1", required = true),
             @Parameter(name = "searchName", description = "검색어", example = "병해중전문가"),
-            @Parameter(name = "page", description = "페이지 번호, 1부터 시작입니다.", example = "1", required = true)
     })
     @GetMapping("/rooms/all")
     public ApiResponse<ChatResponse.ChatRoomListDTO> getChatRoomPage (@RequestParam(name = "userId") @EqualsUserId Long userId,
                                                                       @RequestParam(name = "read") Integer read,
-                                                                      @RequestParam(name = "searchName", required = false) String searchName,
-                                                                      @CheckPage Integer page){
+                                                                      @CheckPage Integer page,
+                                                                      @RequestParam(name = "searchName", required = false) String searchName){
 
         ChatResponse.ChatRoomListDTO response = chatRoomQueryService.findChatRoomBySearch(userId, read, searchName, page);
 

--- a/src/main/java/com/backend/farmon/controller/ChatRoomController.java
+++ b/src/main/java/com/backend/farmon/controller/ChatRoomController.java
@@ -44,7 +44,6 @@ public class ChatRoomController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTHORIZATION_4031", description = "인증된 사용자 정보와 요청된 리소스의 사용자 정보가 다릅니다. (userId 불일치)", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAGE4001", description = "페이지 번호는 1 이상이어야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
@@ -75,7 +74,6 @@ public class ChatRoomController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "EXPERT4001", description = "아이디와 일치하는 전문가가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTHORIZATION_4031", description = "인증된 사용자 정보와 요청된 리소스의 사용자 정보가 다릅니다. (userId 불일치)", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ESTIMATE4001", description = "견적 아이디와 일치하는 견적이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저(전문가)의 아이디(pk)", example = "1", required = true),
@@ -102,7 +100,6 @@ public class ChatRoomController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTHORIZATION_4031", description = "인증된 사용자 정보와 요청된 리소스의 사용자 정보가 다릅니다. (userId 불일치)", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHATROOM4001", description = "채팅방 아이디와 일치하는 채팅방이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
@@ -128,7 +125,6 @@ public class ChatRoomController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHATROOM4001", description = "채팅방 아이디와 일치하는 채팅방이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTHORIZATION_4031", description = "인증된 사용자 정보와 요청된 리소스의 사용자 정보가 다릅니다. (userId 불일치)", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAGE4001", description = "페이지 번호는 1 이상이어야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
@@ -156,7 +152,6 @@ public class ChatRoomController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTHORIZATION_4031", description = "인증된 사용자 정보와 요청된 리소스의 사용자 정보가 다릅니다. (userId 불일치)", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHATROOM4001", description = "채팅방 아이디와 일치하는 채팅방이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
@@ -182,7 +177,6 @@ public class ChatRoomController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTHORIZATION_4031", description = "인증된 사용자 정보와 요청된 리소스의 사용자 정보가 다릅니다. (userId 불일치)", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHATROOM4001", description = "채팅방 아이디와 일치하는 채팅방이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),

--- a/src/main/java/com/backend/farmon/controller/ChatRoomController.java
+++ b/src/main/java/com/backend/farmon/controller/ChatRoomController.java
@@ -35,7 +35,9 @@ public class ChatRoomController {
     @Operation(
             summary = "사용자의 전체 채팅 목록 조회 API",
             description = "사용자의 전체 채팅 목록을 조회하는 API이며, 페이징을 포함합니다. " +
-                    "유저 아이디, 읽음 여부 필터, 페이지 번호를 쿼리 스트링으로 입력해주세요."
+                    "채팅 상대 이름 혹은 작물 이름으로 검색하는 경우에는 검색어를 쿼리 스트링에 입력해 주세요. " +
+                    "검색어를 입력하지 않은 경우에는 전체 채팅 목록을 조회합니다. " +
+                    "유저 아이디, 읽음 여부 필터, 검색어, 페이지 번호를 쿼리 스트링으로 입력해주세요."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
@@ -47,44 +49,16 @@ public class ChatRoomController {
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
             @Parameter(name = "read", description = "읽음 여부 필터링. 안 읽은 채팅방만 필터링 시에는 1, 이외에는 0 입니다.", example = "0", required = true),
+            @Parameter(name = "searchName", description = "검색어", example = "병해중전문가"),
             @Parameter(name = "page", description = "페이지 번호, 1부터 시작입니다.", example = "1", required = true)
     })
     @GetMapping("/rooms/all")
     public ApiResponse<ChatResponse.ChatRoomListDTO> getChatRoomPage (@RequestParam(name = "userId") @EqualsUserId Long userId,
                                                                       @RequestParam(name = "read") Integer read,
+                                                                      @RequestParam(name = "searchName", required = false) String searchName,
                                                                       @CheckPage Integer page){
 
-        ChatResponse.ChatRoomListDTO response = chatRoomQueryService.findChatRoom(userId, read, page);
-
-        return ApiResponse.onSuccess(response);
-    }
-
-
-    // 이름, 작물 이름과 일치하는 채팅 목록 조회
-    @Operation(
-            summary = "채팅 상대 이름 혹은 작물 이름으로 검색하여 일치하는 채팅 목록 조회 API",
-            description = "채팅 상대 이름 혹은 작물 이름으로 검색하여 일치하는 채팅 목록 조회하는 API이며, 페이징을 포함합니다. " +
-                    "유저 아이디, 읽음 여부 필터, 검색할 채팅 상대 이름, 페이지 번호를 쿼리 스트링으로 입력해주세요."
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTHORIZATION_4031", description = "인증된 사용자 정보와 요청된 리소스의 사용자 정보가 다릅니다. (userId 불일치)", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PAGE4001", description = "페이지 번호는 1 이상이어야 합니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-    })
-    @Parameters({
-            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
-            @Parameter(name = "read", description = "읽음 여부 필터링. 안 읽은 채팅방만 필터링 시에는 false, 이외에는 true 입니다.", example = "false", required = true),
-            @Parameter(name = "searchName", description = "검색어", example = "김팜온", required = true),
-            @Parameter(name = "page", description = "페이지 번호, 1부터 시작입니다.", example = "1", required = true)
-    })
-    @GetMapping("/rooms/all/search")
-    public ApiResponse<ChatResponse.ChatRoomListDTO> getChatRoomPageBySearch(@RequestParam(name = "userId") @EqualsUserId Long userId,
-                                                                             @RequestParam(name = "read") String read,
-                                                                             @RequestParam(name = "searchName") String searchName,
-                                                                             @CheckPage Integer page) {
-        ChatResponse.ChatRoomListDTO response = ChatResponse.ChatRoomListDTO.builder().build();
+        ChatResponse.ChatRoomListDTO response = chatRoomQueryService.findChatRoomBySearch(userId, read, searchName, page);
 
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -27,7 +27,8 @@ public class HomeController {
     @Operation(
             summary = "홈 화면 커뮤니티 게시글 조회 API",
             description = "홈 화면에서 커뮤니티 카테고리에 따른 게시글을 조회합니다. " +
-                    "필터링 할 커뮤니티 카테고리 이름을 쿼리 스트링으로 입력해 주세요. "
+                    "필터링 할 커뮤니티 카테고리 이름을 쿼리 스트링으로 입력해 주세요. " +
+                    "로그인한 사용자의 경우 발급받은 토큰을 헤더에 입려해주세요. 로그인하지 않은 사용자의 경우에는 토큰을 입력하지 않아도 됩니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
@@ -47,7 +48,8 @@ public class HomeController {
     // 홈 화면 - 인기 칼럼 조회
     @Operation(
             summary = "홈 화면 인기 칼럼 조회 API",
-            description = "홈 화면에서 인기 칼럼 게시글 목록을 6개 조회합니다."
+            description = "홈 화면에서 인기 칼럼 게시글 목록을 6개 조회합니다." +
+            "로그인한 사용자의 경우 발급받은 토큰을 헤더에 입려해주세요. 로그인하지 않은 사용자의 경우에는 토큰을 입력하지 않아도 됩니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
@@ -60,10 +62,53 @@ public class HomeController {
     }
 
 
+    // 홈 화면 검색 - 자동 완성
+    @Operation(
+            summary = "홈 화면 검색어 목록 조회 API",
+            description = "홈 화면 검색어 입력 시 사용자가 입력한 검색어와 관련된 작물 이름들을 반환합니다. " +
+                    "유저 아이디와 검색어를 쿼리 스트링으로 입력해 주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
+            @Parameter(name = "searchName", description = "검색어", example = "1"),
+    })
+    @GetMapping("/search")
+    public ApiResponse<HomeResponse.AutoCompleteSearchDTO> getHomeAutoCompleteSearchNameList (@RequestParam(name = "userId", required = false) Long userId,
+                                                                                              @RequestParam(name = "searchName") String searchName){
+        HomeResponse.AutoCompleteSearchDTO response = HomeResponse.AutoCompleteSearchDTO.builder().build();;
+        return ApiResponse.onSuccess(response);
+    }
+
+
+    // 홈 화면 검색 - 자동 완성 저장
+    @Operation(
+            summary = "홈 화면 검색어 저장 API",
+            description = "홈 화면 검색어 입력 시 사용자가 입력한 검색어와 관련된 작물 이름들이 반환되었을 때 " +
+                    "반환된 작물 이름들 중 사용자가 원하는 작물을 클릭하면 해당 작물 이름을 저장합니다. " +
+                    "유저 아이디와 저장할 작물 이름을 쿼리 스트링으로 입력해 주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
+            @Parameter(name = "searchName", description = "저장할 작물 이름", example = "1"),
+    })
+    @PostMapping("/search")
+    public ApiResponse<HomeResponse.AutoCompleteSearchDTO> postHomeAutoCompleteSearchNameList (@RequestParam(name = "userId", required = false) Long userId,
+                                                                                               @RequestParam(name = "searchName") String searchName){
+        HomeResponse.AutoCompleteSearchDTO response = HomeResponse.AutoCompleteSearchDTO.builder().build();;
+        return ApiResponse.onSuccess(response);
+    }
+
+
     // 최근 검색어 조회
     @Operation(
             summary = "홈 화면 최근 검색어 조회 API",
-            description = "홈 화면 검색 창에서 사용자의 최근 검색어들을 조회합니다. 로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
+            description = "홈 화면 검색 창에서 사용자의 최근 검색어들을 조회합니다. 유저 아이디를 쿼리 스트링으로 입력해 주세요."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
@@ -71,39 +116,18 @@ public class HomeController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
-            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1")
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1")
     })
     @GetMapping("/search/recent")
-    public ApiResponse<HomeResponse.RecentSearchListDTO> getRecentSearches (@RequestParam(name = "userId", required = false) Long userId){
+    public ApiResponse<HomeResponse.RecentSearchListDTO> getRecentSearches (@RequestParam(name = "userId") Long userId){
         HomeResponse.RecentSearchListDTO response = HomeResponse.RecentSearchListDTO.builder().build();;
         return ApiResponse.onSuccess(response);
     }
 
-
-    // 추천 검색어 조회
-    @Operation(
-            summary = "홈 화면 추천 검색어 조회 API",
-            description = "홈 화면 검색 창에서 추천 검색어들을 조회합니다.  로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
-    )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-    })
-    @Parameters({
-            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1")
-    })
-    @GetMapping("/search/recommend")
-    public ApiResponse<HomeResponse.RecommendSearchListDTO> getRecommendSearches (@RequestParam(name = "userId", required = false) Long userId){
-        HomeResponse.RecommendSearchListDTO response = HomeResponse.RecommendSearchListDTO.builder().build();;
-        return ApiResponse.onSuccess(response);
-    }
-
-
     // 특정 검색어 삭제 API
     @Operation(
-            summary = "홈 화면에서 특정 검색어 삭제 API",
-            description = "홈 화면에서 특정 검색어를 삭제하는 API 입니다. 유저 아이디와 삭제할 검색어 이름을 쿼리 스트링으로 입력해 주세요."
+            summary = "홈 화면에서 최근 검색어에서 특정 검색어 삭제 API",
+            description = "홈 화면에서 최근 검색어 목록에서 특정 검색어를 삭제하는 API 입니다. 유저 아이디와 삭제할 검색어 이름을 쿼리 스트링으로 입력해 주세요."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
@@ -114,10 +138,10 @@ public class HomeController {
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
             @Parameter(name = "name", description = "삭제 할 검색어 이름", example = "병충해 관리")
     })
-    @DeleteMapping("/search")
+    @DeleteMapping("/search/recent")
     public ApiResponse<HomeResponse.SearchDeleteDTO> deleteSearchName(@RequestParam(name = "userId") Long userId,
-                                                                  @RequestParam(name = "name") String searchName){
-        HomeResponse.SearchDeleteDTO response = HomeResponse.SearchDeleteDTO.builder().build();;
+                                                                      @RequestParam(name = "name") String searchName){
+        HomeResponse.SearchDeleteDTO response = HomeResponse.SearchDeleteDTO.builder().build();
         return ApiResponse.onSuccess(response);
     }
 
@@ -135,27 +159,30 @@ public class HomeController {
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1")
     })
-    @DeleteMapping("/search/all")
+    @DeleteMapping("/search/recent/all")
     public ApiResponse<HomeResponse.SearchDeleteDTO> deleteAllSearchName(@RequestParam(name = "userId") Long userId) {
         HomeResponse.SearchDeleteDTO response = HomeResponse.SearchDeleteDTO.builder().build();;
         return ApiResponse.onSuccess(response);
     }
 
-    // 홈 화면 검색 - 자동 완성
-//    @Operation(
-//            summary = "홈 화면 조회 API",
-//            description = "홈 화면 로딩에 필요한 정보를 조회합니다. 로그인 한 사용자의 경우에는 유저 아이디를 쿼리 스트링으로 입력해 주세요."
-//    )
-//    @ApiResponses({
-//            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
-//    })
-//    @Parameters({
-//            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk), 로그인 하지 않은 사용자 일 경우 입력하지 않아도 됩니다.", example = "1"),
-//    })
-//    @GetMapping("/search")
-//    public ApiResponse<HomeResponse.HomePageDTO> getChatRoomPage (@RequestParam(name = "userId", required = false) Long userId,
-//                                                                  @RequestParam(name = "category") String category){
-//        HomeResponse.HomePageDTO response = HomeResponse.HomePageDTO.builder().build();;
-//        return ApiResponse.onSuccess(response);
-//    }
+    // 추천 검색어 조회
+    @Operation(
+            summary = "홈 화면 추천 검색어 조회 API",
+            description = "홈 화면 검색 창에서 추천 검색어들을 조회합니다. 유저 아이디를 쿼리 스트링으로 입력해 주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "아이디와 일치하는 사용자가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1")
+    })
+    @GetMapping("/search/recommend")
+    public ApiResponse<HomeResponse.RecommendSearchListDTO> getRecommendSearches (@RequestParam(name = "userId") Long userId){
+        HomeResponse.RecommendSearchListDTO response = HomeResponse.RecommendSearchListDTO.builder().build();;
+        return ApiResponse.onSuccess(response);
+    }
+
+
 }

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -17,10 +17,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "홈 화면", description = "홈 화면에 관한 API")
 @Slf4j
+@Validated
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/home")
@@ -79,12 +81,12 @@ public class HomeController {
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
-            @Parameter(name = "searchName", description = "검색어", example = "1"),
+            @Parameter(name = "name", description = "검색어", example = "1"),
     })
     @GetMapping("/search")
     public ApiResponse<HomeResponse.AutoCompleteSearchDTO> getHomeAutoCompleteSearchNameList (@RequestParam(name = "userId") @EqualsUserId Long userId,
-                                                                                              @RequestParam(name = "searchName") String searchName){
-        HomeResponse.AutoCompleteSearchDTO response = HomeResponse.AutoCompleteSearchDTO.builder().build();;
+                                                                                              @RequestParam(name = "name") String searchName){
+        HomeResponse.AutoCompleteSearchDTO response = HomeResponse.AutoCompleteSearchDTO.builder().build();
         return ApiResponse.onSuccess(response);
     }
 
@@ -130,8 +132,10 @@ public class HomeController {
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1")
     })
     @GetMapping("/search/recent")
-    public ApiResponse<HomeResponse.RecentSearchListDTO> getRecentSearches (@RequestParam(name = "userId") @EqualsUserId Long userId){
+    public ApiResponse<HomeResponse.RecentSearchListDTO> getRecentSearchNameList (@RequestParam(name = "userId") @EqualsUserId Long userId){
         HomeResponse.RecentSearchListDTO response = searchQueryService.findRecentSearchLogs(userId);
+        log.info("최근 검색어 조회 완료 - userId: {}", userId);
+
         return ApiResponse.onSuccess(response);
     }
 
@@ -194,7 +198,7 @@ public class HomeController {
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1")
     })
     @GetMapping("/search/recommend")
-    public ApiResponse<HomeResponse.RecommendSearchListDTO> getRecommendSearches (@RequestParam(name = "userId") @EqualsUserId Long userId){
+    public ApiResponse<HomeResponse.RecommendSearchListDTO> getRecommendSearchNameList (@RequestParam(name = "userId") @EqualsUserId Long userId){
         HomeResponse.RecommendSearchListDTO response = HomeResponse.RecommendSearchListDTO.builder().build();;
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -98,9 +98,9 @@ public class HomeController {
             @Parameter(name = "searchName", description = "저장할 작물 이름", example = "1"),
     })
     @PostMapping("/search")
-    public ApiResponse<HomeResponse.AutoCompleteSearchDTO> postHomeAutoCompleteSearchNameList (@RequestParam(name = "userId", required = false) Long userId,
+    public ApiResponse<HomeResponse.AutoCompleteSearchPostDTO> postHomeAutoCompleteSearchNameList (@RequestParam(name = "userId", required = false) Long userId,
                                                                                                @RequestParam(name = "searchName") String searchName){
-        HomeResponse.AutoCompleteSearchDTO response = HomeResponse.AutoCompleteSearchDTO.builder().build();;
+        HomeResponse.AutoCompleteSearchPostDTO response = HomeResponse.AutoCompleteSearchPostDTO.builder().build();;
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/backend/farmon/controller/TestController.java
+++ b/src/main/java/com/backend/farmon/controller/TestController.java
@@ -26,7 +26,7 @@ public class TestController {
             redisTemplate.opsForValue().set(key, "Hello, Redis!");
 
             // Redis에서 데이터 가져오기
-            String value = redisTemplate.opsForValue().get("testKey");
+            String value = redisTemplate.opsForValue().get(key);
 
             // 결과 반환
             return value != null ? "Redis 연결 성공! Value: " + value : "Redis 연결 실패!";

--- a/src/main/java/com/backend/farmon/converter/ChatConverter.java
+++ b/src/main/java/com/backend/farmon/converter/ChatConverter.java
@@ -111,23 +111,24 @@ public class ChatConverter {
     }
 
     public static ChatResponse.ChatRoomDetailDTO toChatRoomDetailDTO(
-            ChatRoom chatRoom, ChatMessage chatMessage, Area area, Boolean isExpert, Integer unReadMessageCount) {
+            ChatRoom chatRoom, ChatMessage chatMessage, Area area, Boolean isExpert, Long unReadMessageCount) {
 
+        // 내가 전문가라면 농업인을 user로 가져오기
         User user = isExpert
-                ? chatRoom.getExpert().getUser()
-                : chatRoom.getFarmer();
+                ? chatRoom.getFarmer()
+                : chatRoom.getExpert().getUser();
 
         return ChatResponse.ChatRoomDetailDTO.builder()
                 .chatRoomId(chatRoom.getId())
                 .name(user.getUserName())
-                .profileImage(isExpert && user.getExpert() != null && user.getExpert().getProfileImageUrl() != null
+                .profileImage(!isExpert && user.getExpert() != null && user.getExpert().getProfileImageUrl() != null
                         ? user.getExpert().getProfileImageUrl()
                         : null)
                 .estimateBudget(chatRoom.getEstimate().getBudget())
                 .estimateCategory(chatRoom.getEstimate().getCategory())
                 .estimateAreaName(area.getAreaName())
                 .estimateAreaDetail(area.getAreaNameDetail())
-                .unreadMessageCount(unReadMessageCount)
+                .unreadMessageCount(unReadMessageCount.intValue())
                 .lastMessageContent(chatMessage != null ? chatMessage.getContent() : null) // null-safe 처리
                 .lastMessageDate(chatMessage != null ? ConvertTime.convertToYearMonthDay(chatMessage.getCreatedAt()) : null) // null-safe 처리
                 .build();

--- a/src/main/java/com/backend/farmon/converter/ChatConverter.java
+++ b/src/main/java/com/backend/farmon/converter/ChatConverter.java
@@ -62,6 +62,10 @@ public class ChatConverter {
 
         return ChatResponse.ChatRoomDataDTO.builder()
                 .name(chatRoom.getExpert().getUser().getUserName())
+                .nickName(chatRoom.getExpert().getNickName() != null
+                        ? chatRoom.getExpert().getNickName()
+                        : null)
+                .isExpertNickNameOnly(chatRoom.getExpert().getIsNickNameOnly())
                 .profileImage(chatRoom.getExpert().getProfileImageUrl() != null
                         ? chatRoom.getExpert().getProfileImageUrl()
                         : null)
@@ -121,6 +125,9 @@ public class ChatConverter {
         return ChatResponse.ChatRoomDetailDTO.builder()
                 .chatRoomId(chatRoom.getId())
                 .name(user.getUserName())
+                .nickName(!isExpert ? user.getExpert().getNickName() : null) // 내가 전문가가 아니면(내가 농업인) 상대는 전문가
+                .isExpertNickNameOnly(!isExpert ? user.getExpert().getIsNickNameOnly() : null)
+                .type(isExpert ? "농업인" : "전문가") // 내가 전문가이면 상대 타입은 농업인
                 .profileImage(!isExpert && user.getExpert() != null && user.getExpert().getProfileImageUrl() != null
                         ? user.getExpert().getProfileImageUrl()
                         : null)

--- a/src/main/java/com/backend/farmon/converter/HomeConverter.java
+++ b/src/main/java/com/backend/farmon/converter/HomeConverter.java
@@ -54,4 +54,16 @@ public class HomeConverter {
                 )
                 .build();
     }
+
+    public static HomeResponse.AutoCompleteSearchPostDTO toAutoCompleteSearchPostDTO(){
+        return HomeResponse.AutoCompleteSearchPostDTO.builder()
+                .isSearchSave(true)
+                .build();
+    }
+
+    public static HomeResponse.SearchDeleteDTO toSearchDeleteDTO(){
+        return HomeResponse.SearchDeleteDTO.builder()
+                .isSearchDelete(true)
+                .build();
+    }
 }

--- a/src/main/java/com/backend/farmon/dto/chat/ChatRequest.java
+++ b/src/main/java/com/backend/farmon/dto/chat/ChatRequest.java
@@ -40,7 +40,7 @@ public class ChatRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    @Schema(description = "전송 또는 수신할 채팅 메시지 정보")
+    @Schema(description = "전송 또는 수신할 채팅 메시지 정보(테스트용)")
     public static class TestDTO {
 
         @Schema(description = "보낸 사람 아이디, 현재 로그인한 사용자의 userId와 동일", example = "1")

--- a/src/main/java/com/backend/farmon/dto/chat/ChatResponse.java
+++ b/src/main/java/com/backend/farmon/dto/chat/ChatResponse.java
@@ -45,6 +45,15 @@ public class ChatResponse {
         @Schema(description = "채팅 중인 상대방 이름", example = "김팜온")
         String name;
 
+        @Schema(description = "채팅 중인 상대방 닉네임 (채팅 상대가 전문가일 경우에만 해당) / 채팅 상대가 농업인이면 null", example = "병해충전문가")
+        String nickName;
+
+        @Schema(description = "채팅 중인 상대가 전문가일 경우, 닉네임만 보이게 활성화 여부 / 채팅 상대가 농업인이면 null", example = "true")
+        Boolean isExpertNickNameOnly;
+
+        @Schema(description = "채팅 상대 역할, 농업인 또는 전문가", example = "농업인")
+        String type;
+
         @Schema(description = "채팅 중인 상대방 프로필 이미지")
         String profileImage;
 
@@ -140,6 +149,12 @@ public class ChatResponse {
 
         @Schema(description = "채팅 중인 상대방 이름", example = "김팜온")
         String name;
+
+        @Schema(description = "채팅 중인 상대방 닉네임 (채팅 상대가 전문가일 경우에만 해당)", example = "병해충전문가")
+        String nickName;
+
+        @Schema(description = "채팅 중인 상대가 전문가일 경우, 닉네임만 보이게 활성화 여부", example = "true")
+        Boolean isExpertNickNameOnly;
 
         @Schema(description = "채팅 중인 상대방 프로필 이미지")
         String profileImage;

--- a/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
+++ b/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
@@ -118,4 +118,29 @@ public class HomeResponse {
         @Schema(description = "검색어 삭제 성공 여부", example = "true")
         Boolean isSearchDelete;
     }
+
+    @ToString
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "홈 페이지 자동 완성 검색어 정보")
+    public static class AutoCompleteSearchDTO  {
+
+        @Schema(description = "추천 검색어 리스트")
+        List <String> searchList;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "홈 페이지 자동 완성 검색어 저장 반환 정보")
+    public static class AutoCompleteSearchPostDTO {
+
+        @Schema(description = "검색어 저장 여부", example = "true")
+        Boolean isSearchSave;
+    }
 }

--- a/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
+++ b/src/main/java/com/backend/farmon/dto/home/HomeResponse.java
@@ -128,7 +128,7 @@ public class HomeResponse {
     @Schema(description = "홈 페이지 자동 완성 검색어 정보")
     public static class AutoCompleteSearchDTO  {
 
-        @Schema(description = "추천 검색어 리스트")
+        @Schema(description = "자동 완성 검색어 리스트")
         List <String> searchList;
     }
 

--- a/src/main/java/com/backend/farmon/repository/ChatMessageRepository/ChatMessageRepository.java
+++ b/src/main/java/com/backend/farmon/repository/ChatMessageRepository/ChatMessageRepository.java
@@ -16,8 +16,11 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>,
     @Query("SELECT cm FROM ChatMessage cm WHERE cm.chatRoom.id = :chatRoomId AND cm.type IN :types ORDER BY cm.createdAt DESC")
     Optional<ChatMessage> findLatestMessageByTypes(@Param("chatRoomId") Long chatRoomId, @Param("types") List<ChatMessageType> types);
 
-    // 채팅방 아이디와 일치하면서 isRead가 false인 메시지 리스트 조회
-    List<ChatMessage> findByChatRoomIdAndIsReadFalse(Long chatRoomId);
+    // 채팅방 아이디와 일치하면서 isRead가 false인 메시지 개수 조회
+    long countByChatRoomIdAndIsReadFalseAndTypeIn(Long chatRoomId, List<ChatMessageType> types);
+
+//    @Query("SELECT COUNT(cm) FROM ChatMessage cm WHERE cm.chatRoom.id = :chatRoomId AND cm.isRead = false AND cm.type IN :types")
+//    long countUnreadMessagesByChatRoomIdAndTypes(@Param("chatRoomId") Long chatRoomId, @Param("types") List<ChatMessageType> types);
 
     // 채팅방 아이디와 일치하는 채팅 메시지들 삭제
     @Modifying

--- a/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryCustom.java
@@ -5,9 +5,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ChatRoomRepositoryCustom {
-    // userId와 연관된 채팅방 페이징 조회
-    Page<ChatRoom> findChatRoomsByUserIdAndRole(Long userId, String role, Pageable pageable);
+    // userId와 연관된 검색어와 일치하는 채팅방 페이징 조회
+    Page<ChatRoom> findChatRoomsByUserIdAndRoleAndSearch(Long userId, String role, String searchName, Pageable pageable);
 
-    // userId와 연관된 채팅방 중 안 읽음 메시지가 존재하는 채팅방만 페이징 조회
-    Page<ChatRoom> findUnReadChatRoomsByUserIdAndRole(Long userId, String role, Pageable pageable);
+    // userId와 연관된 검색어와 일치하는 채팅방 중 안 읽음 메시지가 존재하는 채팅방만 페이징 조회
+    Page<ChatRoom> findUnReadChatRoomsByUserIdAndRoleAndSearch(Long userId, String role, String searchName, Pageable pageable);
 }

--- a/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryImpl.java
@@ -20,10 +20,11 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
     QChatRoom chatRoom = QChatRoom.chatRoom;
     QChatMessage chatMessage = QChatMessage.chatMessage;
 
-    // userId와 연관된 채팅방 페이징 조회
     @Override
-    public Page<ChatRoom> findChatRoomsByUserIdAndRole(Long userId, String role, Pageable pageable) {
+    public Page<ChatRoom> findChatRoomsByUserIdAndRoleAndSearch(Long userId, String role, String searchName, Pageable pageable) {
         BooleanBuilder builder = new BooleanBuilder();
+
+        // userId와 연관된 채팅방 조회
         builder.and(chatRoom.farmer.id.eq(userId).or(chatRoom.expert.user.id.eq(userId)));
 
         // role에 따른 조건 추가
@@ -37,6 +38,16 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
 
         // 텍스트, 이미지 메시지만 조회
         builder.and(chatMessage.type.in(ChatMessageType.TEXT, ChatMessageType.IMAGE));
+
+        // 검색어 조건 (세 가지 중 하나라도 포함되면 조회)
+        if (searchName != null && !searchName.trim().isEmpty()) {
+            BooleanBuilder searchCondition = new BooleanBuilder();
+            searchCondition.or(chatRoom.farmer.userName.containsIgnoreCase(searchName)); // 농업인 사용자명 검색
+            searchCondition.or(chatRoom.expert.nickName.containsIgnoreCase(searchName)); // 전문가 닉네임 검색
+            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(true).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시할 경우, 원래 사용자명도 검색
+
+            builder.and(searchCondition); // 전체 조건에 추가
+        }
 
         // 데이터 조회 쿼리
         QueryResults<ChatRoom> results = queryFactory
@@ -54,7 +65,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
 
     // userId와 연관된 채팅방 중 안 읽음 메시지가 존재하는 채팅방만 페이징 조회
     @Override
-    public Page<ChatRoom> findUnReadChatRoomsByUserIdAndRole(Long userId, String role, Pageable pageable) {
+    public Page<ChatRoom> findUnReadChatRoomsByUserIdAndRoleAndSearch(Long userId, String role, String searchName, Pageable pageable) {
         BooleanBuilder builder = new BooleanBuilder();
 
         // role에 따른 조건 추가
@@ -69,6 +80,16 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
         // 안 읽은 텍스트, 이미지 메시지만 조회
         builder.and(chatMessage.isRead.isFalse());
         builder.and(chatMessage.type.in(ChatMessageType.TEXT, ChatMessageType.IMAGE));
+
+        // 검색어 조건 (세 가지 중 하나라도 포함되면 조회)
+        if (searchName != null && !searchName.trim().isEmpty()) {
+            BooleanBuilder searchCondition = new BooleanBuilder();
+            searchCondition.or(chatRoom.farmer.userName.containsIgnoreCase(searchName)); // 농업인 사용자명 검색
+            searchCondition.or(chatRoom.expert.nickName.containsIgnoreCase(searchName)); // 전문가 닉네임 검색
+            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(true).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시할 경우, 원래 사용자명도 검색
+
+            builder.and(searchCondition); // 전체 조건에 추가
+        }
 
         // 데이터 조회 쿼리
         QueryResults<ChatRoom> results = queryFactory

--- a/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryImpl.java
@@ -39,12 +39,15 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
         // 텍스트, 이미지 메시지만 조회
         builder.and(chatMessage.type.in(ChatMessageType.TEXT, ChatMessageType.IMAGE));
 
-        // 검색어 조건 (세 가지 중 하나라도 포함되면 조회)
+        // 검색어 조건 (여섯 가지 중 하나라도 포함되면 조회)
         if (searchName != null && !searchName.trim().isEmpty()) {
             BooleanBuilder searchCondition = new BooleanBuilder();
             searchCondition.or(chatRoom.farmer.userName.containsIgnoreCase(searchName)); // 농업인 사용자명 검색
             searchCondition.or(chatRoom.expert.nickName.containsIgnoreCase(searchName)); // 전문가 닉네임 검색
-            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(true).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시할 경우, 원래 사용자명도 검색
+            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(false).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시하지 않을 경우, 원래 사용자명도 검색
+            searchCondition.or(chatRoom.estimate.crop.category.containsIgnoreCase(searchName)); // 작물 카테고리로 검색
+            searchCondition.or(chatRoom.estimate.crop.name.containsIgnoreCase(searchName)); // 작물 디테일 이름으로 검색
+            searchCondition.or(chatRoom.estimate.category.containsIgnoreCase(searchName)); // 견적 분야로 검색
 
             builder.and(searchCondition); // 전체 조건에 추가
         }
@@ -81,12 +84,15 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
         builder.and(chatMessage.isRead.isFalse());
         builder.and(chatMessage.type.in(ChatMessageType.TEXT, ChatMessageType.IMAGE));
 
-        // 검색어 조건 (세 가지 중 하나라도 포함되면 조회)
+        // 검색어 조건 (여섯 가지 중 하나라도 포함되면 조회)
         if (searchName != null && !searchName.trim().isEmpty()) {
             BooleanBuilder searchCondition = new BooleanBuilder();
             searchCondition.or(chatRoom.farmer.userName.containsIgnoreCase(searchName)); // 농업인 사용자명 검색
             searchCondition.or(chatRoom.expert.nickName.containsIgnoreCase(searchName)); // 전문가 닉네임 검색
-            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(true).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시할 경우, 원래 사용자명도 검색
+            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(false).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시하지 않을 경우, 원래 사용자명도 검색
+            searchCondition.or(chatRoom.estimate.crop.category.containsIgnoreCase(searchName)); // 작물 카테고리로 검색
+            searchCondition.or(chatRoom.estimate.crop.name.containsIgnoreCase(searchName)); // 작물 디테일 이름으로 검색
+            searchCondition.or(chatRoom.estimate.category.containsIgnoreCase(searchName)); // 견적 분야로 검색
 
             builder.and(searchCondition); // 전체 조건에 추가
         }

--- a/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryService.java
+++ b/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryService.java
@@ -3,8 +3,8 @@ package com.backend.farmon.service.ChatRoomService;
 import com.backend.farmon.dto.chat.ChatResponse;
 
 public interface ChatRoomQueryService {
-    // 채팅방 목록 조회
-    ChatResponse.ChatRoomListDTO findChatRoom(Long userId, Integer read, Integer pageNumber);
+    // 검색어 별 채팅방 목록 조회
+    ChatResponse.ChatRoomListDTO findChatRoomBySearch(Long userId, Integer read, String searchName, Integer pageNumber);
 
     // 채팅방 정보 조회 & 안 읽음 메시지 읽음 처리
     ChatResponse.ChatRoomDataDTO findChatRoomDataAndChangeUnreadMessage(Long userId, Long chatRoomId);

--- a/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryServiceImpl.java
@@ -36,8 +36,6 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
     private final UserRepository userRepository;
     private final EstimateRepository estimateRepository;
     private final UserAuthorizationUtil userAuthorizationUtil;
-    private final ChatRoomCommandService chatRoomCommandService;
-    private final WebSocketSessionManager webSocketSessionManager;
 
     private static final Integer PAGE_SIZE=10;
 

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchCommandService.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchCommandService.java
@@ -1,0 +1,13 @@
+package com.backend.farmon.service.SearchService;
+
+public interface SearchCommandService {
+
+    // 사용자 최근 검색어 저장
+    void saveRecentSearchLog(Long userId, String searchName);
+
+    // 사용자 최근 검색어 삭제
+    void deleteRecentSearchLog(Long userId, String searchName);
+
+    // 사용자 최근 검색어 전체 삭제
+    void deleteAllRecentSearchLog(Long userId);
+}

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchCommandServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchCommandServiceImpl.java
@@ -1,0 +1,95 @@
+package com.backend.farmon.service.SearchService;
+
+import com.backend.farmon.apiPayload.code.status.ErrorStatus;
+import com.backend.farmon.apiPayload.exception.handler.SearchHandler;
+import com.backend.farmon.apiPayload.exception.handler.UserHandler;
+import com.backend.farmon.domain.User;
+import com.backend.farmon.repository.UserRepository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class SearchCommandServiceImpl implements SearchCommandService {
+
+    private final UserRepository userRepository;
+    private final RedisTemplate<String, String> recentSearchLogRedisTemplate;
+    private static final int SEARCH_SIZE=10;
+
+
+    // 사용자 최근 검색어 저장
+    @Transactional
+    @Override
+    public void saveRecentSearchLog(Long userId, String searchName) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        if(searchName == null || searchName.isEmpty())
+            throw new SearchHandler(ErrorStatus.SEARCH_NOT_EMPTY);
+
+        String key = "RecentSearchLog" + userId;
+        log.info("입력한 검색어 key, value: " + key + ", " + searchName);
+
+        // key가 이미 존재하는지 확인
+        List<String> searchList = recentSearchLogRedisTemplate.opsForList().range(key, 0, -1);
+        if (searchList != null && searchList.contains(searchName)) {
+            log.info("exists: true");
+            // 이미 존재하는 경우, 해당 검색어를 리스트의 맨 앞으로 이동시켜야 하기 때문에 제거
+            recentSearchLogRedisTemplate.opsForList().remove(key, 0, searchName);
+        }
+
+        Long size = recentSearchLogRedisTemplate.opsForList().size(key);
+
+        // redis의 현재 크기가 10인 경우
+        if (size != null && size == SEARCH_SIZE) {
+            // rightPop을 통해 가장 오래된 데이터 삭제
+            recentSearchLogRedisTemplate.opsForList().rightPop(key);
+        }
+
+        // 새로운 검색어를 추가
+        recentSearchLogRedisTemplate.opsForList().leftPush(key, searchName);
+
+        // 전체 사용자 대상 검색어 추가
+        Double score = recentSearchLogRedisTemplate.opsForZSet().score("RecentSearchLog", searchName);
+        recentSearchLogRedisTemplate.opsForZSet().add("RecentSearchLog", searchName, (score != null) ? score + 1 : 1);
+
+        log.info("최근 검색어 저장 완료 - userId: {}, 검색어: {}", userId, searchName);
+    }
+
+    // 검색어와 일치하는 사용자의 최근 검색어 삭제
+    @Transactional
+    @Override
+    public void deleteRecentSearchLog(Long userId, String searchName) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        String key = "RecentSearchLog" + userId;
+
+        Long count = recentSearchLogRedisTemplate.opsForList().remove(key, 1, searchName);
+        log.info("삭제된 검색어: {}, 검색 횟수: {}", searchName, count);
+    }
+
+    // 사용자 최근 검색어 전체 삭제
+    @Transactional
+    @Override
+    public void deleteAllRecentSearchLog(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        Set<String> keys = recentSearchLogRedisTemplate.keys("RecentSearchLog" + userId);
+
+        if (keys != null && !keys.isEmpty()) {
+            recentSearchLogRedisTemplate.delete(keys);
+        }
+
+        log.info("사용자 최근 검색어 전체 삭제 - userId: {}", userId);
+    }
+}

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchQueryService.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchQueryService.java
@@ -1,0 +1,8 @@
+package com.backend.farmon.service.SearchService;
+
+import com.backend.farmon.dto.home.HomeResponse;
+
+public interface SearchQueryService {
+    // 사용자 최근 검색어 리스트 조회
+    HomeResponse.RecentSearchListDTO findRecentSearchLogs(Long userId);
+}

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
@@ -1,0 +1,24 @@
+package com.backend.farmon.service.SearchService;
+
+import com.backend.farmon.dto.home.HomeResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class SearchQueryServiceImpl implements SearchQueryService{
+    private final RedisTemplate<String, String> recentSearchLogRedisTemplate;
+
+    // 사용자 최근 검색어 리스트 조회
+    @Override
+    public HomeResponse.RecentSearchListDTO findRecentSearchLogs(Long userId) {
+        return HomeResponse.RecentSearchListDTO.builder()
+                .recentSearchList( recentSearchLogRedisTemplate.opsForList().range("RecentSearchLog"+userId, 0, 10))
+                .build();
+    }
+}

--- a/src/main/java/com/backend/farmon/validaton/validator/UserIdEqualsValidator.java
+++ b/src/main/java/com/backend/farmon/validaton/validator/UserIdEqualsValidator.java
@@ -1,15 +1,20 @@
 package com.backend.farmon.validaton.validator;
 
 import com.backend.farmon.apiPayload.code.status.ErrorStatus;
+import com.backend.farmon.apiPayload.exception.handler.AuthorizationHandler;
+import com.backend.farmon.config.security.JWTUtil;
 import com.backend.farmon.config.security.UserAuthorizationUtil;
 import com.backend.farmon.validaton.annotation.EqualsUserId;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 
 // 토큰에 설정되어 있는 userId와 파라미터로 받은 userId가 같은 지 검증
+//@Order(Ordered.HIGHEST_PRECEDENCE + 50) // 우선순위 올리기
 @Component
 @RequiredArgsConstructor
 public class UserIdEqualsValidator implements ConstraintValidator<EqualsUserId, Long> {
@@ -21,16 +26,32 @@ public class UserIdEqualsValidator implements ConstraintValidator<EqualsUserId, 
     }
 
     @Override
-    public boolean isValid(Long values, ConstraintValidatorContext context) {
+    public boolean isValid(Long userId, ConstraintValidatorContext context) {
+        if (userId == null) {
+            return false; // null일 경우 false 반환
+        }
 
-        // 토큰에 설정되어 있는 userId와 파라미터로 받은 userId가 같은 지 검증
-        boolean isValid = userAuthorizationUtil.isCurrentUserIdMatching(values);
+        boolean isValid;
+        try {
+            isValid = userAuthorizationUtil.isCurrentUserIdMatching(userId);
+        } catch (AuthorizationHandler ex) {
+            // Hibernate Validator 내부에서는 예외를 던지지 않고 false 반환
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus._UNAUTHORIZED.toString()).addConstraintViolation();
+            return false;
+        } catch (Exception ex) {
+            // 다른 예외 발생 시도 마찬가지로 처리
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus._INTERNAL_SERVER_ERROR.toString()).addConstraintViolation();
+            return false;
+        }
 
-        if(!isValid){
+        if (!isValid) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(ErrorStatus.AUTHORIZATION_NOT_EQUALS.toString()).addConstraintViolation();
         }
 
         return isValid;
     }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #105 

## 📝작업 내용
홈 화면에서 최근 검색어 저장, 최근 검색어 목록 조회, 특정 검색어 삭제,  최근 검색어 전체 삭제를 redis를 이용하여 구현하였습니다.

로그인 하지 않은 사용자의 경우는 401 에러를 반환하도록 하였습니다.

### 스크린샷 
<img width="869" alt="image" src="https://github.com/user-attachments/assets/780600a8-dab3-463e-8c67-cc5ab5072247" />
로그인 하지 않은 사용자의 경우 COMMON401 에러가 반환됩니다.

&nbsp;
<img width="854" alt="image" src="https://github.com/user-attachments/assets/6aa26e20-e250-435b-a344-4d6384b1e7fb" />
인증이 완료되면 사용자의 최근 검색어가 리스트로 반환됩니다.


## 💬리뷰 요구사항(선택)

> 전체적으로 로그인이 필요한 경로(조회 관련 부분 제외)에 대해, 로그인하지 않은 사용자가 요청할 경우 401 에러를 반환하도록 수정이 필요할 것 같습니다. 이 부분은 월요일 회의에서 논의해보면 좋을 것 같아요.