### PR TITLE
♻️[Refactor] 채팅 메시지 전송 시간 포맷 변경, Post 엔티티 좋아요 횟수 컬럼 오타 수정 

### DIFF
--- a/src/main/java/com/backend/farmon/converter/ConvertTime.java
+++ b/src/main/java/com/backend/farmon/converter/ConvertTime.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 
 // CreatedAt 포맷 클래스
 public class ConvertTime {
@@ -64,7 +65,10 @@ public class ConvertTime {
 
     // 24시간 형식을 오전/오후 형식으로 변환
     public static String convertToAmPmFormat(LocalDateTime dateTime) {
-        return dateTime.format(DateTimeFormatter.ofPattern("a h:mm"));
+        if (dateTime == null) {
+            return null;
+        }
+        return dateTime.format(DateTimeFormatter.ofPattern("a h:mm", Locale.KOREAN));
     }
 
     // LocalDateTime을 "2025.01.10" 형식의 문자열로 변환

--- a/src/main/java/com/backend/farmon/domain/Post.java
+++ b/src/main/java/com/backend/farmon/domain/Post.java
@@ -1,12 +1,7 @@
 package com.backend.farmon.domain;
 
-import com.backend.farmon.domain.Board;
-import com.backend.farmon.domain.Comment;
-import com.backend.farmon.domain.LikeCount;
-import com.backend.farmon.domain.User;
 import com.backend.farmon.domain.commons.BaseEntity;
 import com.backend.farmon.dto.Filter.FieldCategory;
-import com.backend.farmon.dto.post.PostType;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
@@ -46,7 +41,8 @@ public class Post extends BaseEntity {
     @JsonBackReference
     private User user;
 
-    private int poslikes;
+    @Column(columnDefinition = "INTEGER DEFAULT 0", nullable = false)
+    private int postLikes;
 
     @Enumerated(EnumType.STRING)
     private FieldCategory fieldCategory;
@@ -72,11 +68,11 @@ public class Post extends BaseEntity {
     }
 
     public void increaseLikes() {
-        this.poslikes++;
+        this.postLikes++;
     }
 
     public void decreaseLikes() {
-        this.poslikes--;
+        this.postLikes--;
     }
 
     public int getLikeCount() {

--- a/src/main/java/com/backend/farmon/repository/ChatMessageRepository/ChatMessageRepository.java
+++ b/src/main/java/com/backend/farmon/repository/ChatMessageRepository/ChatMessageRepository.java
@@ -13,8 +13,10 @@ import java.util.Optional;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, ChatMessageRepositoryCustom {
     // 채팅방 아이디와 일치하는 가장 최신 메시지 조회
-    @Query("SELECT cm FROM ChatMessage cm WHERE cm.chatRoom.id = :chatRoomId AND cm.type IN :types ORDER BY cm.createdAt DESC")
-    Optional<ChatMessage> findLatestMessageByTypes(@Param("chatRoomId") Long chatRoomId, @Param("types") List<ChatMessageType> types);
+    @Query(value = "SELECT * FROM chat_message cm WHERE cm.chat_room_id = :chatRoomId AND cm.type IN (:types) ORDER BY cm.created_at DESC LIMIT 1",
+            nativeQuery = true)
+    Optional<ChatMessage> findLatestMessageByTypes(@Param("chatRoomId") Long chatRoomId,
+                                                   @Param("types") List<String> types);
 
     // 채팅방 아이디와 일치하면서 isRead가 false인 메시지 개수 조회
     long countByChatRoomIdAndIsReadFalseAndTypeIn(Long chatRoomId, List<ChatMessageType> types);

--- a/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryServiceImpl.java
@@ -61,7 +61,7 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         log.info("안 읽음 필터링에 따른 유저의 모든 채팅방 목록 페이지네이션 조회 완료 - userId: {}", userId);
 
         // 최신 메시지 타입 (썸네일에서는 텍스트만)
-        List<ChatMessageType> targetTypes = List.of(ChatMessageType.TEXT);
+        List<String> targetTypes = List.of(ChatMessageType.TEXT.toString());
 
         // 안 읽은 메시지 개수 조회 타입 (텍스트, 이미지)
         List<ChatMessageType> unReadTargetTypes = List.of(ChatMessageType.TEXT, ChatMessageType.IMAGE);


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #110 

## 📝작업 내용
- 기존에는 채팅 메시지 저장 & 조회 시 pm 11:08 형식으로 반환하였는데 이를 오후 11:08 형식으로 변경
- `Post` 엔티티 좋아요 횟수 컬럼이 postlikes 로 되어 있어서 오타를 수정하여 `postLikes`로 수정하였습니다. 확인 부탁드려요


### 스크린샷 (선택)
<img width="413" alt="image" src="https://github.com/user-attachments/assets/0c25b1a4-0026-4d1b-8f13-4709914c47c5" />
