### PR TITLE
🐛[Fix] cors 허용 origin, method 변경

### DIFF
--- a/src/main/java/com/backend/farmon/config/WebConfig.java
+++ b/src/main/java/com/backend/farmon/config/WebConfig.java
@@ -19,10 +19,10 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
 
         registry.addMapping("/**") // 모든 경로에 대해 CORS 허용
-                .allowedOrigins("http://localhost:3000") // 허용할 Origin 설정
+                .allowedOrigins("http://localhost:5173") // 허용할 Origin 설정
                 .allowedHeaders("*") // 요청을 허용할 헤더 설정
                 .exposedHeaders("*")  // 응답 헤더 설정
-                .allowedMethods("*") // 허용할 HTTP 메서드 명시
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS") // 허용할 HTTP 메서드 명시
                 .allowCredentials(true) // 자격 증명(쿠키, 인증 헤더 등)을 포함한 요청을 허용
                 .maxAge(3600); // Preflight 요청 결과를 캐시하는 시간 (초)
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #117 

## 📝작업 내용

cors 허용 origin, method를 변경했습니다.
기존에는 locahost:3000 에서 오는 요청을 허용했지만, localhost:5173(프론트 주소)로 변경하였습니다.
허용 메서드는 기존에는 *(와일드카드)를 이용하였지만, 명시적으로 허용할 메서드를 추가하였습니다.

## 스크린샷
<img width="650" alt="image" src="https://github.com/user-attachments/assets/42fa4758-9606-4e19-8cf2-b870d7129ad0" />
