### PR TITLE
✨[Feat] 휴대전화 인증, 공통 회원정보 조회/수정 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ dependencies {
 
 	//redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// 문자인증 api coolSMS
+	implementation 'net.nurigo:sdk:4.3.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
@@ -39,6 +39,11 @@ public enum ErrorStatus implements BaseErrorCode {
     // 회원가입 에러
     EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "PAGE4001", "이미 가입된 이메일주소입니다."),
 
+    // 문자인증 관련 에러
+    PHONENUM_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "SMS4001", "해당 전화번호로 가입한 계정이 이미 존재합니다."),
+    PHONENUM_NOT_EXIST(HttpStatus.BAD_REQUEST, "SMS4002", "해당 전화번호로 발급된 인증번호가 존재하지 않습니다."),
+    AUTHCODE_INVALID(HttpStatus.BAD_REQUEST, "SMS4003", "인증문자가 만료되었습니다."),
+
     // 커뮤니티 게시판   
     POST_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_TYPE4001", "지원되지 않는 게시판 타입 입니다."),
     POST_NOT_SAVED(HttpStatus.BAD_REQUEST, "POST_TYPE4002", "게시글이 저장되지 않았습니다."),

--- a/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
+++ b/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
@@ -41,8 +41,8 @@ public class SecurityConfig { // 애플리케이션의 보안 정책을 정의
 //                        .requestMatchers("/").authenticated()
 
                         // 공용 접근 허용 (누구나 접근 가능)
-                        .requestMatchers("/api/login","/api/user/join","/api/expert/join", "/api/home/community", "/api/home/popular",
-                                "/api/expert/list", "/api/expert/career/**",
+                        .requestMatchers("/api/login","/api/generate","/api/verify","/api/user/join", "/api/home/community", "/api/home/popular",
+                                "/api/expert/list", "/api/expert/{expert-id}",
                                 "/api/posts/popular/list/**", "/api/posts/all/list/**", "/api/posts/free/list/**","/api/posts/qna/list/**",
                                 "/api/posts/expertCol/list/**", "/api/posts/{postId}/comments").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll() // Swagger 경로 허용

--- a/src/main/java/com/backend/farmon/controller/SignupController.java
+++ b/src/main/java/com/backend/farmon/controller/SignupController.java
@@ -15,6 +15,7 @@ import com.backend.farmon.dto.user.SignupRequest;
 import com.backend.farmon.dto.user.SignupResponse;
 import com.backend.farmon.repository.UserRepository.UserRepository;
 import com.backend.farmon.service.ExpertService.ExpertCommandService;
+import com.backend.farmon.service.SmsService.SmsService;
 import com.backend.farmon.service.UserService.UserCommandService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -31,9 +32,52 @@ import static com.backend.farmon.domain.QExpertCareer.expertCareer;
 @RestController
 @RequiredArgsConstructor
 public class SignupController {
+    private final SmsService smsService;
     private final UserCommandService userCommandService;
     private final ExpertCommandService expertCommandService;
     private final UserRepository userRepository;
+
+    // 문자인증 코드 요청
+    @PostMapping("/api/generate")
+    @Operation(summary = "본인인증 코드문자 요청 API",
+            description = "api요청시 해당 휴대폰 번호로 인증문자가 발송됩니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "phoneNum", description = "휴대폰 번호. -없이 숫자만 입력해주세요 ex)01012345678")
+    })
+    public ApiResponse<String> sendSms(@RequestParam String phoneNum) {
+        try {
+            boolean result = smsService.sendSms(phoneNum);
+            if(!result) return ApiResponse.onFailure("ERR_SMS_SEND", "인증 코드 전송에 실패했습니다. 다시 시도해주세요.", null);
+        } catch (Exception e) {
+            return ApiResponse.onFailure("ERR_SMS_SEND", "인증 코드 전송에 실패했습니다. 다시 시도해주세요.", null);
+        }
+        return ApiResponse.onSuccess("인증 코드가 전송되었습니다.");
+    }
+
+    // 문자인증 코드 검증
+    @PostMapping("/api/verify")
+    @Operation(summary = "본인인증 코드 검증 API",
+            description = "api요청시 인증번호가 일치하는지 검토합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "phoneNum", description = "휴대폰 번호. -없이 숫자만 입력해주세요"),
+            @Parameter(name = "inputCode", description = "인증 코드를 넣어주세요.")
+    })
+    public ApiResponse<String> verifyAuthCode(@RequestParam String phoneNum, @RequestParam String inputCode) {
+        boolean isVerified = smsService.verifyAuthCode(phoneNum, inputCode);
+        if (isVerified) {
+            return ApiResponse.onSuccess("인증이 성공적으로 완료되었습니다.");
+        } else {
+            return ApiResponse.onFailure("ERR_SMS_SEND", "인증 코드가 잘못되었습니다.", null);
+        }
+    }
 
     @PostMapping("/api/user/join")
     @Operation(summary = "농업인 회원가입 API")

--- a/src/main/java/com/backend/farmon/converter/ExpertConverter.java
+++ b/src/main/java/com/backend/farmon/converter/ExpertConverter.java
@@ -201,14 +201,16 @@ public class ExpertConverter {
 
     public static ExpertProfileResponse.PortfolioDetailDTO portfolioViewDTO(Portfolio portfolio) {
         return ExpertProfileResponse.PortfolioDetailDTO.builder()
+                .portfolioId(portfolio.getId())
                 .thumbnailImg(portfolio.getThumbnailImg())
-                .name(portfolio.getTitle())
+                .title(portfolio.getTitle())
                 .build();
     }
 
 
     public static ExpertProfileResponse.ExpertCareerDTO expertCareerViewDTO(ExpertCareer expertCareer) {
         return ExpertProfileResponse.ExpertCareerDTO.builder()
+                .careerId(expertCareer.getId())
                 .title(expertCareer.getTitle())
                 .startYear(expertCareer.getStartYear())
                 .startMonth(expertCareer.getStartMonth())

--- a/src/main/java/com/backend/farmon/converter/UserConverter.java
+++ b/src/main/java/com/backend/farmon/converter/UserConverter.java
@@ -1,8 +1,16 @@
 package com.backend.farmon.converter;
 
 import com.backend.farmon.domain.Expert;
+import com.backend.farmon.domain.ExpertCareer;
+import com.backend.farmon.domain.User;
+import com.backend.farmon.domain.enums.Gender;
 import com.backend.farmon.domain.enums.Role;
+import com.backend.farmon.dto.expert.ExpertCareerResponse;
 import com.backend.farmon.dto.user.ExchangeResponse;
+import com.backend.farmon.dto.user.MypageResponse;
+import com.backend.farmon.dto.user.SignupRequest;
+
+import java.time.LocalDate;
 
 public class UserConverter {
     public static ExchangeResponse toExchangeResponse(Long userId, String role, Expert expert, String token) {
@@ -17,5 +25,16 @@ public class UserConverter {
         }
 
         return responseBuilder.build();
+    }
+
+    // 유저 마이페이지 응답 DTO 생성
+    public static MypageResponse.UserInfoDTO toUserInfoGetResultDTO(User user) {
+        return MypageResponse.UserInfoDTO.builder()
+                .name(user.getUserName())
+                .birth(user.getBirthDate())
+                .gender(user.getGender())
+                .phone(user.getPhoneNum())
+                .email(user.getEmail())
+                .build();
     }
 }

--- a/src/main/java/com/backend/farmon/dto/expert/ExpertProfileResponse.java
+++ b/src/main/java/com/backend/farmon/dto/expert/ExpertProfileResponse.java
@@ -75,11 +75,14 @@ public class ExpertProfileResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class PortfolioDetailDTO {
+        @Schema(description = "포트폴리오 ID")
+        Long portfolioId;
+
         @Schema(description = "포트폴리오 썸네일 이미지")
         String thumbnailImg;
 
         @Schema(description = "포트폴리오 제목")
-        String name;
+        String title;
     }
 
     @Builder
@@ -87,6 +90,9 @@ public class ExpertProfileResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ExpertCareerDTO {
+        @Schema(description = "경력 ID")
+        Long careerId;
+
         @Schema(description = "전문가 경력 제목")
         String title;
 

--- a/src/main/java/com/backend/farmon/dto/user/MypageRequest.java
+++ b/src/main/java/com/backend/farmon/dto/user/MypageRequest.java
@@ -1,6 +1,9 @@
 package com.backend.farmon.dto.user;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -12,8 +15,15 @@ public class MypageRequest {
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL) // null 값인 필드는 JSON에 포함되지 않음
     @Schema(description = "마이페이지 수정 요청 DTO")
     public static class UpdateUserInfoDTO{
+        @Schema(description = "이름", example = "홍길동")
+        String name;
+
+        @Schema(description = "생년월일", example = "2025-01-01")
+        LocalDate birth;
+
         @Schema(description = "변경할 이메일 주소", example = "umc@gmail.com")
         String email;
 

--- a/src/main/java/com/backend/farmon/dto/user/MypageResponse.java
+++ b/src/main/java/com/backend/farmon/dto/user/MypageResponse.java
@@ -1,5 +1,6 @@
 package com.backend.farmon.dto.user;
 
+import com.backend.farmon.domain.enums.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -12,25 +13,12 @@ public class MypageResponse {
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "마이페이지 조회시 응답 DTO")
+    @Schema(description = "마이페이지 응답 DTO")
     public static class UserInfoDTO{
         String name;
         LocalDate birth;
-        String gender;  // String으로 받되, 후에 Enum으로 변환
+        Gender gender;
         String phone;
         String email;
-        String password;
     }
-
-    @Builder
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Schema(description = "마이페이시 수정시 응답 DTO")
-    public static class UpdateUserInfoResultDTO{
-        String email;
-        String password;
-    }
-
 }

--- a/src/main/java/com/backend/farmon/repository/SmsAuthRepository/SmsAuthRepository.java
+++ b/src/main/java/com/backend/farmon/repository/SmsAuthRepository/SmsAuthRepository.java
@@ -1,0 +1,10 @@
+package com.backend.farmon.repository.SmsAuthRepository;
+
+import com.backend.farmon.domain.SmsAuth;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SmsAuthRepository extends JpaRepository<SmsAuth, Long> {
+    Optional<SmsAuth> findByPhoneNum(String phoneNum);
+}

--- a/src/main/java/com/backend/farmon/repository/UserRepository/UserRepository.java
+++ b/src/main/java/com/backend/farmon/repository/UserRepository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
     Boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+    boolean existsByPhoneNum(String phoneNum);
 }

--- a/src/main/java/com/backend/farmon/service/SmsService/SmsService.java
+++ b/src/main/java/com/backend/farmon/service/SmsService/SmsService.java
@@ -1,0 +1,6 @@
+package com.backend.farmon.service.SmsService;
+
+public interface SmsService {
+    boolean sendSms(String phoneNumber);
+    boolean verifyAuthCode(String phoneNumber, String inputCode);
+}

--- a/src/main/java/com/backend/farmon/service/SmsService/SmsServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SmsService/SmsServiceImpl.java
@@ -1,0 +1,106 @@
+package com.backend.farmon.service.SmsService;
+
+import com.backend.farmon.apiPayload.code.status.ErrorStatus;
+import com.backend.farmon.apiPayload.exception.handler.UserHandler;
+import com.backend.farmon.domain.SmsAuth;
+import com.backend.farmon.repository.SmsAuthRepository.SmsAuthRepository;
+import com.backend.farmon.repository.UserRepository.UserRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SmsServiceImpl implements SmsService {
+
+    private final SmsAuthRepository smsAuthRepository;
+    private final UserRepository userRepository;
+    private DefaultMessageService messageService;
+
+    @Value("${spring.sms.api-key}")
+    private String apiKey;
+    @Value("${spring.sms.api-secret}")
+    private String apiSecret;
+    @Value("${spring.sms.provider}")
+    private String smsProvider; // 수신자
+    @Value("${spring.sms.sender}")
+    private String smsSender; // 발신자
+
+    @PostConstruct
+    public void init(){
+        messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, smsProvider);
+    }
+
+    // 인증 코드 생성
+    @Override
+    @Transactional
+    public boolean sendSms(String phoneNum) {
+        // 가입한 번호가 이미 존재하는지 검증
+        if (userRepository.existsByPhoneNum(phoneNum)) {
+            throw new UserHandler(ErrorStatus.PHONENUM_ALREADY_EXIST);  // 전화번호가 이미 존재할 경우 예외 발생
+        }
+        // 기존 인증있으면(인증문자 재발급일 경우) 해당 엔티티 삭제
+        smsAuthRepository.findByPhoneNum(phoneNum)
+                .ifPresent(smsAuthRepository::delete);
+
+        // 전송할 message객체 생성
+        Message message = new Message();
+        // 발신번호 및 수신번호는 반드시 01012345678 형태로 입력되어야 합니다.
+        message.setFrom(smsSender);
+        message.setTo(phoneNum);
+
+        // 새 인증 코드 생성
+        String certificationCode = Integer.toString((int)(Math.random() * (999999 - 100000 + 1)) + 100000); // 6자리 인증 코드를 랜덤으로 생성
+
+        // 문자인증 엔티티 생성
+        SmsAuth newSmsAuth = SmsAuth.builder()
+                .phoneNum(phoneNum)
+                .authCode(certificationCode)
+                .expirationTime(LocalDateTime.now().plusMinutes(3)) // 3분 후 만료
+                .build();
+        smsAuthRepository.save(newSmsAuth);
+
+        message.setText("FarmOn 본인확인 인증번호는 " + certificationCode + "입니다.");
+
+        // 문자 전송
+        SingleMessageSentResponse response = this.messageService.sendOne(new SingleMessageSendingRequest(message));
+
+        String statusCode = response.getStatusCode();
+        boolean result = statusCode.equals("2000"); // 전송성공시 statusCode는 2000. 다른 값이 담길시 result는 false가 됨
+        return result;
+    }
+
+    // 인증 코드 검증
+    @Override
+    @Transactional
+    public boolean verifyAuthCode(String phoneNumber, String inputCode) {
+        // 입력 번호에 해당하는 인증 코드 엔티티 가져옴
+        Optional<SmsAuth> optionalSmsAuth = smsAuthRepository.findByPhoneNum(phoneNumber);
+
+        // 해당 번호에 해당하는 엔티티가 존재하지 않으면 에러발생
+        if (optionalSmsAuth.isEmpty()) {
+            throw new UserHandler(ErrorStatus.PHONENUM_NOT_EXIST);
+        }
+        // 해당 번호로 생성된 인증 번호 엔티티가 존재한다면(아직 인증번호 일치하는지 검사는 안함), 해당 인증 코드 객체를 가져옴
+        SmsAuth smsAuth = optionalSmsAuth.get();
+
+        // 인증 코드의 만료 시간이 현재 시간보다 이전인지 확인
+        if (smsAuth.getExpirationTime().isBefore(LocalDateTime.now())) {
+            smsAuthRepository.delete(smsAuth); // 만료된 객체 삭제
+            throw new UserHandler(ErrorStatus.AUTHCODE_INVALID);
+        }
+
+        // 입력한 인증 코드와 데이터베이스에서 가져온 인증 코드가 일치하는지 비교
+        return smsAuth.getAuthCode().equals(inputCode);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #122 

## 📝작업 내용

휴대전화 인증문자 발송/확인 api와 공통 회원정보 조회/수정 api 구현하였습니다. 
문자인증시 발급된 인증코드는 3분동안 유효하며 하루에 문자발송은 최대 50번까지 가능합니다. coolSMS가 발신번호로 인증된 번호만 등록이 가능해서 일단 발신번호는 제 번호로 문자가 가게 설정해 두었습니다! 
application.yml파일 수정되었으니 노션에서 복붙한 다음에 프로그램 돌려 주세요!

+SecurityConfig에 인증문자 관련 api와 전문가 프로필 조회 api는 비로그인 유저도 접근 가능하도록 추가하고 전문가 전환 api는 삭제했습니다. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 편하게 피드백주세요!