### PR TITLE
✨[Feat] 홈 화면 추천 검색어 리스트 조회 구현

### DIFF
--- a/src/main/java/com/backend/farmon/FarmonApplication.java
+++ b/src/main/java/com/backend/farmon/FarmonApplication.java
@@ -3,7 +3,9 @@ package com.backend.farmon;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class FarmonApplication {

--- a/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
@@ -32,6 +32,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 채팅방 관련 에러
     CHATROOM_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHATROOM4001", "채팅방 아이디와 일치하는 채팅방이 없습니다."),
+    CHATROOM_CREATE_ONLY_EXPERT(HttpStatus.FORBIDDEN, "CHATROOM4031", "채팅방 생성은 전문가만 가능합니다."),
 
     // 페이지 번호
     PAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "PAGE4001", "페이지 번호는 1 이상이어야 합니다."),

--- a/src/main/java/com/backend/farmon/config/AsyncConfig.java
+++ b/src/main/java/com/backend/farmon/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.backend.farmon.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean(name = "customAsyncExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5); // 기본적으로 유지할 스레드 수
+        executor.setMaxPoolSize(5); // 최대 생성 가능한 스레드 수
+        executor.setQueueCapacity(100); // 작업 대기열의 크기, 최대 풀 크기 이상의 작업이 들어올 경우 대기열에 저장되는 작업 수
+        executor.setThreadNamePrefix("Async-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/backend/farmon/config/RedisConfig.java
+++ b/src/main/java/com/backend/farmon/config/RedisConfig.java
@@ -27,14 +27,32 @@ public class RedisConfig {
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 
-    // 사용자 최근 검색어 저장
-    @Bean
-    @Primary
-    public RedisTemplate<String, String> recentSeachLogRedisTemplate() {
+    // 사용자 최근 검색어 저장 (RecentSearch+userId, 검색어)
+    @Bean(name = "recentSearchLogRedisTemplate")
+    public RedisTemplate<String, String> recentSearchLogRedisTemplate() {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
+
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+
+        return redisTemplate;
+    }
+
+    // 추천 검색어 저장 (RecommendSearch+userId, 작물 이름)
+    @Bean(name = "recommendSearchLogRedisTemplate")
+    public RedisTemplate<String, String> recommendSearchLogRedisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // Key 직렬화 (String)
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+        // Value 직렬화
         redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
 

--- a/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
+++ b/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
@@ -44,7 +44,8 @@ public class SecurityConfig { // 애플리케이션의 보안 정책을 정의
                         .requestMatchers("/api/login","/api/user/join","/api/expert/join", "/api/home/community", "/api/home/popular",
                                 "/api/expert/list", "/api/expert/career/**",
                                 "/api/posts/popular/list/**", "/api/posts/all/list/**", "/api/posts/free/list/**","/api/posts/qna/list/**",
-                                "/api/posts/expertCol/list/**", "/api/posts/{postId}/comments").permitAll()
+                                "/api/posts/expertCol/list/**", "/api/posts/{postId}/comments",
+                                "/ws-stomp/**", "test/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll() // Swagger 경로 허용
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/backend/farmon/controller/ChatRoomController.java
+++ b/src/main/java/com/backend/farmon/controller/ChatRoomController.java
@@ -73,10 +73,11 @@ public class ChatRoomController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "EXPERT4001", description = "아이디와 일치하는 전문가가 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTHORIZATION_4031", description = "인증된 사용자 정보와 요청된 리소스의 사용자 정보가 다릅니다. (userId 불일치)", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CHATROOM_4031", description = "채팅방 생성은 전문가만 가능합니다", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ESTIMATE4001", description = "견적 아이디와 일치하는 견적이 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
-            @Parameter(name = "userId", description = "로그인한 유저(전문가)의 아이디(pk)", example = "1", required = true),
+            @Parameter(name = "expertId", description = "로그인한 유저의 아이디(pk)", example = "1", required = true),
             @Parameter(name = "estimateId", description = "채팅하려는 견적의 아이디", example = "1", required = true),
     })
     @PostMapping("/room")

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -200,9 +200,10 @@ public class HomeController {
         try {
             log.info("추천 검색어 스케줄링 실행");
             HomeResponse.RecommendSearchListDTO response = searchQueryService.getRecommendSearchNameRank();
+
             recommendSearchListFuture = CompletableFuture.completedFuture(ResponseEntity.ok().body(response));
         } catch (Exception e) {
-            System.err.println("Error during scheduled task: " + e.getMessage());
+            log.warn("추천 검색어 스케줄링 실패: " + e.getMessage());
             recommendSearchListFuture = null;
         }
     }

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -17,8 +17,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 @Tag(name = "홈 화면", description = "홈 화면에 관한 API")
 @Slf4j
@@ -30,6 +37,7 @@ public class HomeController {
     private final PostQueryService postQueryService;
     private final SearchCommandService searchCommandService;
     private final SearchQueryService searchQueryService;
+    private CompletableFuture< ResponseEntity<HomeResponse.RecommendSearchListDTO> > recommendSearchListFuture;
 
     // 홈 화면 - 커뮤니티 게시글 조회
     @Operation(
@@ -184,6 +192,21 @@ public class HomeController {
         return ApiResponse.onSuccess(HomeConverter.toSearchDeleteDTO());
     }
 
+    // 추천 검색어 스케줄링
+    // 매일 1일 오전 1시에 스케줄링된 작업, 추천 검색어 리스트 불러오기 실행
+    @Scheduled(cron = "0 0 1 1 * *", zone = "Asia/Seoul")
+    @Async("customAsyncExecutor")
+    public void recommendSearchListSchedule() {
+        try {
+            log.info("추천 검색어 스케줄링 실행");
+            HomeResponse.RecommendSearchListDTO response = searchQueryService.getRecommendSearchNameRank();
+            recommendSearchListFuture = CompletableFuture.completedFuture(ResponseEntity.ok().body(response));
+        } catch (Exception e) {
+            System.err.println("Error during scheduled task: " + e.getMessage());
+            recommendSearchListFuture = null;
+        }
+    }
+
     // 추천 검색어 조회
     @Operation(
             summary = "홈 화면 추천 검색어 조회 API",
@@ -198,8 +221,24 @@ public class HomeController {
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1")
     })
     @GetMapping("/search/recommend")
-    public ApiResponse<HomeResponse.RecommendSearchListDTO> getRecommendSearchNameList (@RequestParam(name = "userId") @EqualsUserId Long userId){
-        HomeResponse.RecommendSearchListDTO response = HomeResponse.RecommendSearchListDTO.builder().build();
+    public ApiResponse<HomeResponse.RecommendSearchListDTO> getRecommendSearchNameList(@RequestParam(name = "userId") @EqualsUserId Long userId) {
+        try {
+            // 완료된 스케줄링된 작업이 있는 경우
+            if (recommendSearchListFuture != null && recommendSearchListFuture.isDone()) {
+                HomeResponse.RecommendSearchListDTO response = recommendSearchListFuture.get().getBody();
+                log.info("스케줄링된 추천 검색어 리스트 반환");
+
+                return ApiResponse.onSuccess(response);
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            // 예외 발생 시 에러 응답 반환
+            return ApiResponse.onFailure("INTERNAL_SERVER_ERROR", e.getMessage(), null);
+        }
+
+        // 스케줄링된 작업이 없거나 실패했을 경우 새로운 추천 검색어 조회 실행
+        HomeResponse.RecommendSearchListDTO response = searchQueryService.getRecommendSearchNameRank();
+        log.info("스케줄링된 작업이 없어 추천 검색어 리스트 조회 후 반환");
+
         return ApiResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/backend/farmon/controller/TestController.java
+++ b/src/main/java/com/backend/farmon/controller/TestController.java
@@ -20,16 +20,15 @@ public class TestController {
     }
 
     @GetMapping("/test-redis/set")
-    public String testRedis(@RequestParam String key) {
+    public String testRedis(@RequestParam String key, @RequestParam String value) {
         try {
             // Redis에 데이터 저장
-            stringRedisTemplate.opsForValue().set(key, "Hello, Redis!");
+            stringRedisTemplate.opsForValue().set(key, value);
 
             // Redis에서 데이터 가져오기
-            String value = stringRedisTemplate.opsForValue().get(key);
+            String redisValue = stringRedisTemplate.opsForValue().get(key);
 
-            // 결과 반환
-            return value != null ? "Redis 연결 성공! Value: " + value : "Redis 연결 실패!";
+            return redisValue != null ? "Redis 연결 성공! Value: " + redisValue : "Redis 연결 실패!";
         } catch (Exception e) {
             log.error(e.getMessage());
             return "Redis 오류: " + e.getMessage();

--- a/src/main/java/com/backend/farmon/controller/TestController.java
+++ b/src/main/java/com/backend/farmon/controller/TestController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TestController {
 
     @Autowired
-    private RedisTemplate<String, String> redisTemplate;
+    private RedisTemplate<String, String> stringRedisTemplate;
 
     @GetMapping("/test")
     public String test(){
@@ -23,10 +23,10 @@ public class TestController {
     public String testRedis(@RequestParam String key) {
         try {
             // Redis에 데이터 저장
-            redisTemplate.opsForValue().set(key, "Hello, Redis!");
+            stringRedisTemplate.opsForValue().set(key, "Hello, Redis!");
 
             // Redis에서 데이터 가져오기
-            String value = redisTemplate.opsForValue().get(key);
+            String value = stringRedisTemplate.opsForValue().get(key);
 
             // 결과 반환
             return value != null ? "Redis 연결 성공! Value: " + value : "Redis 연결 실패!";
@@ -40,7 +40,7 @@ public class TestController {
     public String checkKey(@RequestParam String key) {
         try {
             // Redis에 해당 키가 존재하는지 확인
-            Boolean exists = redisTemplate.hasKey(key);
+            Boolean exists = stringRedisTemplate.hasKey(key);
 
             // 결과 반환
             if (exists != null && exists) {

--- a/src/main/java/com/backend/farmon/dto/post/PostType.java
+++ b/src/main/java/com/backend/farmon/dto/post/PostType.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "게시판 타입")
 public enum PostType {
-    ALL, POPULAR, QNA, EXPERT_LOUNGE, EXPERT_COLUMN;
+    ALL, POPULAR, QNA, EXPERT_LOUNGE, EXPERT_COLUMN, FREE;
 
 
 }

--- a/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomCommandService.java
+++ b/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomCommandService.java
@@ -7,7 +7,7 @@ import com.backend.farmon.dto.chat.ChatResponse;
 public interface ChatRoomCommandService {
 
     // 채팅방 생성
-    ChatResponse.ChatRoomCreateDTO addChatRoom(Long userId, Long estimateId);
+    ChatResponse.ChatRoomCreateDTO addChatRoom(Long expertId, Long estimateId);
 
     // 채팅방 삭제
     ChatResponse.ChatRoomDeleteDTO removeChatRoom(Long userId, Long chatRoomId);

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchCommandService.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchCommandService.java
@@ -10,4 +10,10 @@ public interface SearchCommandService {
 
     // 사용자 최근 검색어 전체 삭제
     void deleteAllRecentSearchLog(Long userId);
+
+    // 추천 검색어 저장
+    void saveRecommendSearchLog(Long userId, String cropName);
+
+    // 특정 추천 검색어 삭제
+    void deleteRecommendSearchLog(Long userId, String cropName);
 }

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchQueryService.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchQueryService.java
@@ -2,7 +2,12 @@ package com.backend.farmon.service.SearchService;
 
 import com.backend.farmon.dto.home.HomeResponse;
 
+import java.util.List;
+
 public interface SearchQueryService {
     // 사용자 최근 검색어 리스트 조회
     HomeResponse.RecentSearchListDTO findRecentSearchLogs(Long userId);
+
+    // 추천 검색어 스케줄링
+    HomeResponse.RecommendSearchListDTO getRecommendSearchNameRank();
 }

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
@@ -1,11 +1,19 @@
 package com.backend.farmon.service.SearchService;
 
+import com.backend.farmon.converter.ConvertTime;
 import com.backend.farmon.dto.home.HomeResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -13,12 +21,39 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class SearchQueryServiceImpl implements SearchQueryService{
     private final RedisTemplate<String, String> recentSearchLogRedisTemplate;
+    private final RedisTemplate<String, String> recommendSearchLogRedisTemplate;
 
     // 사용자 최근 검색어 리스트 조회
     @Override
     public HomeResponse.RecentSearchListDTO findRecentSearchLogs(Long userId) {
         return HomeResponse.RecentSearchListDTO.builder()
-                .recentSearchList( recentSearchLogRedisTemplate.opsForList().range("RecentSearchLog"+userId, 0, 10))
+                .recentSearchList( recentSearchLogRedisTemplate.opsForList().range("RecentSearchLog"+userId, 0, 9))
                 .build();
+    }
+
+    // 추천 검색어 스케줄링
+    @Override
+    public HomeResponse.RecommendSearchListDTO getRecommendSearchNameRank(){
+        return HomeResponse.RecommendSearchListDTO.builder()
+                .recommendSearchList(recommendSearchNameRankList())
+                .build();
+    }
+
+    // 추천 검색어 리스트 조회
+     List<String> recommendSearchNameRankList(){
+        String key= "RecommendSearchLog";
+        ZSetOperations<String, String> zSetOperations = recommendSearchLogRedisTemplate.opsForZSet();
+
+        // score 순으로 10개 보여줌 (value, score) 형태
+        Set<ZSetOperations.TypedTuple<String>> typedTuples = zSetOperations.reverseRangeWithScores(key, 0, 9);
+
+        // 검색어만 추출하여 리스트로 변환
+        if (typedTuples != null) {
+            return typedTuples.stream()
+                    .map(ZSetOperations.TypedTuple::getValue)
+                    .collect(Collectors.toList());
+        }
+
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

>- #124 

## 📝작업 내용
홈 화면에서 추천 검색어를 조회하는 기능을 구현하였습니다.
견적이 저장될 때 해당 견적의 작물 이름이 추천 검색어로 등록됩니다.
추천 검색어는 가장 많이 저장된 견적의 작물 순위(최대 10개)를 기준으로 반환됩니다.

추가로 채팅방 생성에서, 전문가 설정 부분이 오류가 있어 수정하였습니다.
또한 `SecurityConfig`에 채팅 연결 및 test 컨트롤러 주소도 추가하였습니다. (채팅 연결 시에는 헤더에 토큰을 입력하여야 하는데, SecurityConfig의 공용 접근 허용 주소에 채팅 연결 주소가 포함되어 있지 않으면 연결이 되지 않아 추가하였습니다.)

## 스크린샷
<img width="968" alt="image" src="https://github.com/user-attachments/assets/57e086d8-fb95-45e3-a24d-99a445977934" />


## 💬리뷰 요구사항(선택)

> 피드백 있으면 말씀해주세요!