### PR TITLE
✨[Feat] 홈 화면 자동 완성 검색어 목록 조회 구현

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -65,11 +65,11 @@ jobs:
             # Docker Login
             sudo docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"
             
-            # Stop and Remove All Running Containers Except redis-container
-            if [ "$(sudo docker ps -q | grep -v $(sudo docker ps -q -f name=redis-container))" ]; then
-              sudo docker rm -f $(sudo docker ps -q | grep -v $(sudo docker ps -q -f name=redis-container))
+            # Stop and Remove All Running Containers
+            if [ -n "$(sudo docker ps -aq)" ]; then
+              sudo docker rm -f $(sudo docker ps -aq)
             fi
-            
+  
             # Pull Latest Docker Image
             sudo docker pull "${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}:latest"
             

--- a/redis.conf
+++ b/redis.conf
@@ -1,0 +1,39 @@
+# 연결 가능한 네트위크
+bind 0.0.0.0
+
+# 연결 포트
+port 6379
+
+dir /data
+
+# 설정된 최대 사용 메모리 용량을 초과했을때 처리 방식
+# - noeviction : 쓰기 동작에 대해 error 반환 (Default)
+# - volatile-lru : expire 가 설정된 key 들중에서 LRU algorithm 에 의해서 선택된 key 제거
+# - allkeys-lru : 모든 key 들 중 LRU algorithm에 의해서 선택된 key 제거
+# - volatile-random : expire 가 설정된 key 들 중 임의의 key 제거
+# - allkeys-random : 모든 key 들 중 임의의 key 제거
+# - volatile-ttl : expire time(TTL)이 가장 적게 남은 key 제거 (minor TTL)
+maxmemory-policy volatile-ttl
+
+# == RDB 관련 설정 ==
+# 저장할 RDB 파일명
+dbfilename backup.rdb
+# 15분 안에 최소 1개 이상의 key가 변경 되었을 때
+save 900 1
+# 5분 안에 최소 10개 이상의 key가 변경 되었을 때
+save 300 10
+# 60초 안에 최소 10000개 이상의 key가 변경 되었을 때
+save 60 10000
+# RDB 저장 실패 시 write 명령 차단 여부
+stop-writes-on-bgsave-error no
+
+# == AOF 관련 설정 ==
+# AOF 사용 여부
+appendonly yes
+# 저장할 AOF 파일명
+appendfilename appendonly.aof
+# 디스크와 동기화 처리 방식
+# - always : AOF 값을 추가할 때마다 fsync를 호출해서 디스크에 쓰기
+# - everysec : 매초마다 fsync를 호출해서 디스크에 쓰기
+# - no : OS가 실제 sync를 할 때까지 따로 설정하지 않음
+# appendfsync everysec

--- a/src/main/java/com/backend/farmon/config/RedisConfig.java
+++ b/src/main/java/com/backend/farmon/config/RedisConfig.java
@@ -27,7 +27,7 @@ public class RedisConfig {
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 
-    // 사용자 최근 검색어 저장 (RecentSearch+userId, 검색어)
+    // 사용자 최근 검색어 저장 (RecentSearchLog, 검색어)
     @Bean(name = "recentSearchLogRedisTemplate")
     public RedisTemplate<String, String> recentSearchLogRedisTemplate() {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
@@ -42,9 +42,26 @@ public class RedisConfig {
         return redisTemplate;
     }
 
-    // 추천 검색어 저장 (RecommendSearch+userId, 작물 이름)
+    // 추천 검색어 저장 (RecommendSearchLog, 작물 이름)
     @Bean(name = "recommendSearchLogRedisTemplate")
     public RedisTemplate<String, String> recommendSearchLogRedisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // Key 직렬화 (String)
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+        // Value 직렬화
+        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+
+        return redisTemplate;
+    }
+
+    // 자동 완성 검색어 저장 (AutoSearchLog, 작물 이름)
+    @Bean(name = "autoSearchLogRedisTemplate")
+    public RedisTemplate<String, String> autoSearchLogRedisTemplate() {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 

--- a/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
+++ b/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig { // 애플리케이션의 보안 정책을 정의
                                 "/api/expert/list", "/api/expert/{expert-id}",
                                 "/api/posts/popular/list/**", "/api/posts/all/list/**", "/api/posts/free/list/**","/api/posts/qna/list/**",
                                 "/api/posts/expertCol/list/**", "/api/posts/{postId}/comments",
-                                "/ws-stomp/**", "test/**").permitAll()
+                                "/ws-stomp/**", "/test", "/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll() // Swagger 경로 허용
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -193,7 +193,7 @@ public class HomeController {
     }
 
     // 추천 검색어 스케줄링
-    // 매일 1일 오전 1시에 스케줄링된 작업, 추천 검색어 리스트 불러오기 실행
+    // 매월 1일 오전 1시에 스케줄링된 작업, 추천 검색어 리스트 불러오기 실행
     @Scheduled(cron = "0 0 1 1 * *", zone = "Asia/Seoul")
     @Async("customAsyncExecutor")
     public void recommendSearchListSchedule() {

--- a/src/main/java/com/backend/farmon/controller/HomeController.java
+++ b/src/main/java/com/backend/farmon/controller/HomeController.java
@@ -24,6 +24,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -78,8 +79,8 @@ public class HomeController {
 
     // 홈 화면 검색 - 자동 완성
     @Operation(
-            summary = "홈 화면 검색어 목록 조회 API",
-            description = "홈 화면 검색어 입력 시 사용자가 입력한 검색어와 관련된 작물 이름들을 반환합니다. " +
+            summary = "홈 화면 자동 완성 검색어 목록 조회 API",
+            description = "홈 화면에서 검색어 입력 시 사용자가 입력한 검색어와 관련된 작물 카테고리, 이름들을 반환합니다. " +
                     "유저 아이디와 검색어를 쿼리 스트링으로 입력해 주세요."
     )
     @ApiResponses({
@@ -89,13 +90,13 @@ public class HomeController {
     })
     @Parameters({
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
-            @Parameter(name = "name", description = "검색어", example = "1"),
+            @Parameter(name = "name", description = "검색어", example = "곡"),
     })
     @GetMapping("/search")
     public ApiResponse<HomeResponse.AutoCompleteSearchDTO> getHomeAutoCompleteSearchNameList (@RequestParam(name = "userId") @EqualsUserId Long userId,
                                                                                               @RequestParam(name = "name") String searchName){
-        HomeResponse.AutoCompleteSearchDTO response = HomeResponse.AutoCompleteSearchDTO.builder().build();
-        return ApiResponse.onSuccess(response);
+        List<String> searchList = searchQueryService.autoSearchNameList(searchName);
+        return ApiResponse.onSuccess(HomeConverter.toAutoCompleteSearchDTO(searchList));
     }
 
 

--- a/src/main/java/com/backend/farmon/controller/TestController.java
+++ b/src/main/java/com/backend/farmon/controller/TestController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -63,6 +64,13 @@ public class TestController {
     public  HomeResponse.RecommendSearchListDTO testRecommendRedis(@RequestParam Long userId, @RequestParam String value) {
         // Redis에 데이터 저장
         searchCommandService.saveRecommendSearchLog(userId, value);
+
+        return searchQueryService.getRecommendSearchNameRank();
+    }
+
+    @DeleteMapping("/test-redis/delete/recommend")
+    public  HomeResponse.RecommendSearchListDTO testDeleteRecommendRedis(@RequestParam Long userId, @RequestParam String value) {
+        searchCommandService.deleteRecommendSearchLog(userId, value);
 
         return searchQueryService.getRecommendSearchNameRank();
     }

--- a/src/main/java/com/backend/farmon/controller/TestController.java
+++ b/src/main/java/com/backend/farmon/controller/TestController.java
@@ -1,5 +1,9 @@
 package com.backend.farmon.controller;
 
+import com.backend.farmon.dto.home.HomeResponse;
+import com.backend.farmon.service.SearchService.SearchCommandService;
+import com.backend.farmon.service.SearchService.SearchQueryService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -8,11 +12,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
+@RequiredArgsConstructor
 @RestController
 public class TestController {
 
-    @Autowired
-    private RedisTemplate<String, String> stringRedisTemplate;
+    private final RedisTemplate<String, String> stringRedisTemplate;
+    private final SearchCommandService searchCommandService;
+    private final SearchQueryService searchQueryService;
 
     @GetMapping("/test")
     public String test(){
@@ -53,4 +59,11 @@ public class TestController {
         }
     }
 
+    @GetMapping("/test-redis/set/recommend")
+    public  HomeResponse.RecommendSearchListDTO testRecommendRedis(@RequestParam Long userId, @RequestParam String value) {
+        // Redis에 데이터 저장
+        searchCommandService.saveRecommendSearchLog(userId, value);
+
+        return searchQueryService.getRecommendSearchNameRank();
+    }
 }

--- a/src/main/java/com/backend/farmon/controller/UserController.java
+++ b/src/main/java/com/backend/farmon/controller/UserController.java
@@ -17,6 +17,7 @@ import com.backend.farmon.dto.user.MypageResponse;
 import com.backend.farmon.dto.user.SignupRequest;
 import com.backend.farmon.repository.UserRepository.UserRepository;
 import com.backend.farmon.service.UserService.UserQueryService;
+import com.backend.farmon.validaton.annotation.EqualsUserId;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -29,9 +30,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
+@Validated
 @Tag(name = "사용자 정보")
 @RestController
 @RequiredArgsConstructor
@@ -106,7 +109,7 @@ public class UserController {
             @Parameter(name = "userId", description = "로그인한 유저의 아이디(pk)", example = "1"),
             @Parameter(name = "role", description = "전환하고자 하는 사용자 유형(ADMIN 제외), 전문가 전환 시 EXPERT, 농업인 전환 시 FARMER", example = "EXPERT")
     })
-    public ApiResponse<ExchangeResponse> getExchangeRole(@RequestParam(name="userId") Long userId,
+    public ApiResponse<ExchangeResponse> getExchangeRole(@RequestParam(name="userId") @EqualsUserId Long userId,
                                                          @RequestParam(name="role", defaultValue = "EXPERT") Role role,
                                                          HttpServletRequest request) {
         // JWTUtil을 통해 토큰 추출

--- a/src/main/java/com/backend/farmon/converter/HomeConverter.java
+++ b/src/main/java/com/backend/farmon/converter/HomeConverter.java
@@ -66,4 +66,10 @@ public class HomeConverter {
                 .isSearchDelete(true)
                 .build();
     }
+
+    public static HomeResponse.AutoCompleteSearchDTO toAutoCompleteSearchDTO(List<String> searchList){
+        return HomeResponse.AutoCompleteSearchDTO.builder()
+                .searchList(searchList)
+                .build();
+    }
 }

--- a/src/main/java/com/backend/farmon/repository/CropRepository/CropRepository.java
+++ b/src/main/java/com/backend/farmon/repository/CropRepository/CropRepository.java
@@ -3,9 +3,28 @@ package com.backend.farmon.repository.CropRepository;
 import com.backend.farmon.domain.Area;
 import com.backend.farmon.domain.Crop;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface CropRepository extends JpaRepository<Crop, Long> {
     Optional<Crop> findByName(String name);
+
+    // 중복을 제외한 모든 작물 카테고리 반환
+    @Query("SELECT DISTINCT c.category FROM Crop c")
+    List<String> findAllCropCategory();
+
+    // 모든 작물 이름 반환
+    @Query("SELECT c.name FROM Crop c")
+    List<String> findAllCropName();
+
+    // 카테고리와 일치하는 작물 반환
+    List<Crop> findByCategory(String category);
+
+    // 카테고리에 해당하는 모든 작물 이름 반환
+    @Query("SELECT c.name FROM Crop c WHERE c.category IN :categories")
+    List<String> findCropNamesByCategories(@Param("categories") Set<String> categories);
 }

--- a/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/ChatRoomService/ChatRoomQueryServiceImpl.java
@@ -69,7 +69,7 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
         // 채팅 대화방 세부 정보 목록 생성
         List<ChatResponse.ChatRoomDetailDTO> chatRoomInfoList = chatRoomPage.stream().map(chatRoom -> {
             // 전문가 여부
-            boolean isExpert = chatRoom.getExpert().getId().equals(userId);
+            boolean isExpert = chatRoom.getExpert().getUser().getId().equals(userId);
             log.info("채팅방에서 전문가 여부: {}", isExpert);
 
             // 안 읽은 채팅 메시지 개수 조회
@@ -105,7 +105,7 @@ public class ChatRoomQueryServiceImpl implements ChatRoomQueryService {
                 .orElseThrow(() -> new ChatRoomHandler(ErrorStatus.CHATROOM_NOT_FOUND));
 
         // 채팅방 입장 시 접속 시간 수정
-        boolean isExpert = chatRoom.getExpert().getId().equals(userId);
+        boolean isExpert = chatRoom.getExpert().getUser().getId().equals(userId);
 //        chatRoomCommandService.changeChatRoomEnterTime(userId, chatRoomId, isExpert);
 //        log.info("채팅방 입장 접속 시간 변경 - userId: {}, chatRoomId: {}, 전문가 여부: {}", userId, chatRoomId, isExpert);
 

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchCommandServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchCommandServiceImpl.java
@@ -26,7 +26,7 @@ public class SearchCommandServiceImpl implements SearchCommandService {
 
     private static final int SEARCH_SIZE=10;
     private static final String RECOMMEND_SEARCH_KEY="RecommendSearchLog"; // 추천 검색어 key
-
+    private final String recentSearchKey ="RecentSearchLog"; // 최근 검색어 key
 
     // 사용자 최근 검색어 저장
     @Transactional
@@ -38,7 +38,7 @@ public class SearchCommandServiceImpl implements SearchCommandService {
         if(searchName == null || searchName.isEmpty())
             throw new SearchHandler(ErrorStatus.SEARCH_NOT_EMPTY);
 
-        String key = "RecentSearchLog" + userId;
+        String key = recentSearchKey + userId;
         log.info("입력한 검색어 key, value: " + key + ", " + searchName);
 
         // key가 이미 존재하는지 확인
@@ -74,7 +74,7 @@ public class SearchCommandServiceImpl implements SearchCommandService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        String key = "RecentSearchLog" + userId;
+        String key = recentSearchKey + userId;
 
         Long count = recentSearchLogRedisTemplate.opsForList().remove(key, 1, searchName);
         log.info("삭제된 최근 검색어: {}, 검색 횟수: {}", searchName, count);
@@ -87,7 +87,7 @@ public class SearchCommandServiceImpl implements SearchCommandService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        Set<String> keys = recentSearchLogRedisTemplate.keys("RecentSearchLog" + userId);
+        Set<String> keys = recentSearchLogRedisTemplate.keys(recentSearchKey + userId);
 
         if (keys != null && !keys.isEmpty()) {
             recentSearchLogRedisTemplate.delete(keys);

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchCommandServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchCommandServiceImpl.java
@@ -25,6 +25,7 @@ public class SearchCommandServiceImpl implements SearchCommandService {
     private final RedisTemplate<String, String> recommendSearchLogRedisTemplate;
 
     private static final int SEARCH_SIZE=10;
+    private static final String RECOMMEND_SEARCH_KEY="RecommendSearchLog"; // 추천 검색어 key
 
 
     // 사용자 최근 검색어 저장
@@ -105,12 +106,11 @@ public class SearchCommandServiceImpl implements SearchCommandService {
         if(cropName == null || cropName.isEmpty())
             throw new SearchHandler(ErrorStatus.SEARCH_NOT_EMPTY);
 
-        String key = "RecommendSearchLog";
-        log.info("입력한 검색어 key, value: " + key + ", " + cropName);
+        log.info("입력한 검색어 key, value: " + RECOMMEND_SEARCH_KEY + ", " + cropName);
 
         // 전체 사용자 대상 검색어 추가
-        Double score = recommendSearchLogRedisTemplate.opsForZSet().score(key, cropName);
-        recommendSearchLogRedisTemplate.opsForZSet().add(key, cropName, (score != null) ? score + 1 : 1);
+        Double score = recommendSearchLogRedisTemplate.opsForZSet().score(RECOMMEND_SEARCH_KEY, cropName);
+        recommendSearchLogRedisTemplate.opsForZSet().add(RECOMMEND_SEARCH_KEY, cropName, (score != null) ? score + 1 : 1);
 
         log.info("추천 검색어 저장 완료 - userId: {}, 검색어: {}", userId, cropName);
     }
@@ -122,9 +122,7 @@ public class SearchCommandServiceImpl implements SearchCommandService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        String key = "RecommendSearchLog";
-
-        Long count = recommendSearchLogRedisTemplate.opsForList().remove(key, 1, cropName);
+        Long count = recommendSearchLogRedisTemplate.opsForList().remove(RECOMMEND_SEARCH_KEY, 1, cropName);
         log.info("삭제된 추천 검색어: {}, 검색 횟수: {}", cropName, count);
     }
 }

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchCommandServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchCommandServiceImpl.java
@@ -136,7 +136,7 @@ public class SearchCommandServiceImpl implements SearchCommandService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        Long count = recommendSearchLogRedisTemplate.opsForList().remove(RECOMMEND_SEARCH_KEY, 1, cropName);
+        Long count = recommendSearchLogRedisTemplate.opsForZSet().remove(RECOMMEND_SEARCH_KEY, 1, cropName);
         log.info("삭제된 추천 검색어: {}, 검색 횟수: {}", cropName, count);
     }
 

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchCommandServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchCommandServiceImpl.java
@@ -20,7 +20,6 @@ import java.util.concurrent.Executors;
 
 @Slf4j
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 @Service
 public class SearchCommandServiceImpl implements SearchCommandService {
 
@@ -48,7 +47,6 @@ public class SearchCommandServiceImpl implements SearchCommandService {
 
 
     // 사용자 최근 검색어 저장
-    @Transactional
     @Override
     public void saveRecentSearchLog(Long userId, String searchName) {
         User user = userRepository.findById(userId)
@@ -87,7 +85,7 @@ public class SearchCommandServiceImpl implements SearchCommandService {
     }
 
     // 검색어와 일치하는 사용자의 최근 검색어 삭제
-    @Transactional
+
     @Override
     public void deleteRecentSearchLog(Long userId, String searchName) {
         User user = userRepository.findById(userId)
@@ -100,7 +98,6 @@ public class SearchCommandServiceImpl implements SearchCommandService {
     }
 
     // 사용자 최근 검색어 전체 삭제
-    @Transactional
     @Override
     public void deleteAllRecentSearchLog(Long userId) {
         User user = userRepository.findById(userId)
@@ -116,7 +113,6 @@ public class SearchCommandServiceImpl implements SearchCommandService {
     }
 
     // 추천 검색어 저장
-    @Transactional
     @Override
     public void saveRecommendSearchLog(Long userId, String cropName) {
         User user = userRepository.findById(userId)
@@ -135,7 +131,6 @@ public class SearchCommandServiceImpl implements SearchCommandService {
     }
 
     // 특정 추천 검색어 삭제
-    @Transactional
     @Override
     public void deleteRecommendSearchLog(Long userId, String cropName) {
         User user = userRepository.findById(userId)

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchQueryService.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchQueryService.java
@@ -10,4 +10,7 @@ public interface SearchQueryService {
 
     // 추천 검색어 스케줄링
     HomeResponse.RecommendSearchListDTO getRecommendSearchNameRank();
+
+    // 자동 완성 검색어 조회
+    List<String> autoSearchNameList(String keyword);
 }

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
@@ -64,6 +64,8 @@ public class SearchQueryServiceImpl implements SearchQueryService{
         return Collections.emptyList();
     }
 
+    // 자동 완성 검색어 조회
+    @Override
     public List<String> autoSearchNameList(String keyword) {
         Long index = findFromSortedSet(keyword);  // 사용자가 입력한 검색어를 바탕으로 Redis에서 조회한 결과 매칭되는 index
 

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
@@ -24,12 +24,13 @@ public class SearchQueryServiceImpl implements SearchQueryService{
     private final RedisTemplate<String, String> recommendSearchLogRedisTemplate;
 
     private static final String RECOMMEND_SEARCH_KEY="RecommendSearchLog"; // 추천 검색어 key
+    private final String recentSearchKey="RecentSearchLog"; // 최근 검색어 key
 
     // 사용자 최근 검색어 리스트 조회
     @Override
     public HomeResponse.RecentSearchListDTO findRecentSearchLogs(Long userId) {
         return HomeResponse.RecentSearchListDTO.builder()
-                .recentSearchList( recentSearchLogRedisTemplate.opsForList().range("RecentSearchLog"+userId, 0, 9))
+                .recentSearchList( recentSearchLogRedisTemplate.opsForList().range(recentSearchKey+userId, 0, 9))
                 .build();
     }
 

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
@@ -23,6 +23,8 @@ public class SearchQueryServiceImpl implements SearchQueryService{
     private final RedisTemplate<String, String> recentSearchLogRedisTemplate;
     private final RedisTemplate<String, String> recommendSearchLogRedisTemplate;
 
+    private static final String RECOMMEND_SEARCH_KEY="RecommendSearchLog"; // 추천 검색어 key
+
     // 사용자 최근 검색어 리스트 조회
     @Override
     public HomeResponse.RecentSearchListDTO findRecentSearchLogs(Long userId) {
@@ -41,11 +43,10 @@ public class SearchQueryServiceImpl implements SearchQueryService{
 
     // 추천 검색어 리스트 조회
      List<String> recommendSearchNameRankList(){
-        String key= "RecommendSearchLog";
         ZSetOperations<String, String> zSetOperations = recommendSearchLogRedisTemplate.opsForZSet();
 
         // score 순으로 10개 보여줌 (value, score) 형태
-        Set<ZSetOperations.TypedTuple<String>> typedTuples = zSetOperations.reverseRangeWithScores(key, 0, 9);
+        Set<ZSetOperations.TypedTuple<String>> typedTuples = zSetOperations.reverseRangeWithScores(RECOMMEND_SEARCH_KEY, 0, 9);
 
         // 검색어만 추출하여 리스트로 변환
         if (typedTuples != null) {

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
@@ -76,9 +76,9 @@ public class SearchQueryServiceImpl implements SearchQueryService{
 
         Set<String> allValuesAfterIndexFromSortedSet = findAllValuesAfterIndexFromSortedSet(index);   // 사용자 검색어 이후로 정렬된 Redis 데이터들 가져오기
 
-        // 자동 완성 검색어 리스트 생성
+        // 자동 완성 검색어 리스트 생성 (키워드가 단어 어디에 있든 포함되도록 수정)
         List<String> autoCorrectKeywordList = allValuesAfterIndexFromSortedSet.stream()
-                .filter(value -> value.endsWith(suffix) && value.startsWith(keyword))
+                .filter(value -> value.contains(keyword) && value.endsWith(suffix)) // startsWith -> contains 변경
                 .map(value -> StringUtils.removeEnd(value, suffix))
                 .limit(maxSize)
                 .collect(Collectors.toList());

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
@@ -48,7 +48,9 @@ public class SearchQueryServiceImpl implements SearchQueryService{
     }
 
     // 추천 검색어 리스트 조회
-     List<String> recommendSearchNameRankList(){
+     private List<String> recommendSearchNameRankList(){
+        log.info("추천 검색어 리스트 조회");
+
         ZSetOperations<String, String> zSetOperations = recommendSearchLogRedisTemplate.opsForZSet();
 
         // score 순으로 10개 보여줌 (value, score) 형태
@@ -68,8 +70,9 @@ public class SearchQueryServiceImpl implements SearchQueryService{
     @Override
     public List<String> autoSearchNameList(String keyword) {
         Long index = findFromSortedSet(keyword);  // 사용자가 입력한 검색어를 바탕으로 Redis에서 조회한 결과 매칭되는 index
+        log.info("index: {}", index);
 
-        if (index == null) {
+        if (index == null || index == 0) {
             // 만약 사용자 검색어 바탕으로 자동 완성 검색어를 만들 수 없으면 추천 검색어 리스트 반환
             return recommendSearchNameRankList();
         }

--- a/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SearchService/SearchQueryServiceImpl.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 @Service
 public class SearchQueryServiceImpl implements SearchQueryService{
     private final CropRepository cropRepository;
@@ -64,27 +63,6 @@ public class SearchQueryServiceImpl implements SearchQueryService{
 
         return Collections.emptyList();
     }
-
-    // 자동 완성 검색어 조회
-    // 검색어 자동 완성 기능 관련 로직
-//    public List<String> autoSearchNameList(String keyword) {
-//        Long index = findFromSortedSet(keyword);  // 사용자가 입력한 검색어를 바탕으로 Redis에서 조회한 결과 매칭되는 index
-//
-//        if (index == null) {
-//            // 만약 사용자 검색어 바탕으로 자동 완성 검색어를 만들 수 없으면 추천 검색어 리스트 반환
-//            return recommendSearchNameRankList();
-//        }
-//
-//        Set<String> allValuesAfterIndexFromSortedSet = findAllValuesAfterIndexFromSortedSet(index);   //사용자 검색어 이후로 정렬된 Redis 데이터들 가져오기
-//
-//        List<String> autoCorrectKeywordList = allValuesAfterIndexFromSortedSet.stream()
-//                .filter(value -> value.endsWith(suffix) && value.startsWith(keyword))
-//                .map(value -> StringUtils.removeEnd(value, suffix))
-//                .limit(maxSize)
-//                .toList();  //자동 완성을 통해 만들어진 최대 maxSize개의 키워드들
-//
-//        return autoCorrectKeywordList;
-//    }
 
     public List<String> autoSearchNameList(String keyword) {
         Long index = findFromSortedSet(keyword);  // 사용자가 입력한 검색어를 바탕으로 Redis에서 조회한 결과 매칭되는 index


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #127 

## 📝작업 내용
홈 화면에서 사용자가 검색어를 입력하면, 연관된 작물 카테고리 혹은 이름들이 자동 완성 기능을 통해 제공됩니다.
검색어가 작물 카테고리(곡물, 채소작물, 과일 등)와 연관된다면, 작물 카테고리와 연관된 작물 이름 리스트도 함께 반환됩니다.
연관된 작물 카테고리, 이름이 없다면 추천 검색어 리스트를 제공합니다.

원래는 'ㄱ'만 입력해도 'ㄱ'으로 시작하는 곡물, 감자 등이 반환되어야 하는데, 현재는 추천 리스트가 반환됩니다.
이 부분이 시간이 조금 걸릴 수도 있을 것 같아 일단 구현한 부분까지 머지하고, 추후에 다시 리팩토링 하겠습니다.

+) 추가로 채팅방쪽 농업인, 전문가 type 오류가 있어서 수정하였습니다.
+) `SecurityConfig` 에 기본 경로 /** 도 인증 없이 접근 가능하도록 수정하였습니다.
+) 자동 완성 검색 참고 글: https://sungjindev.github.io/posts/spring-redis-autocorrect1/

### 스크린샷 (선택)
<img width="863" alt="image" src="https://github.com/user-attachments/assets/6ae2fc8d-37c5-4e8a-a01f-d955400ad745" />
사용자가 검색창에 '곡' 입력 시 자동완성을 통해 작물 카테고리인 곡물 및 곡물에 해당하는 작물 이름들이 함께 반환됩니다.

&nbsp;
<img width="868" alt="image" src="https://github.com/user-attachments/assets/11e8fd57-7e84-437e-be75-a5e66effb361" />
검색창에 '감' 입력 시 '감'과 연관된 작물 이름들이 반환됩니다.

&nbsp;
<img width="862" alt="image" src="https://github.com/user-attachments/assets/045dc8f1-854d-4e6d-82b7-6d7b2a40edfa" />
검색어와 연관된 작물이 없다면, 추천 검색어 리스트가 반환됩니다.

## 💬리뷰 요구사항(선택)

> 피드백 있으시면 편하게 주세요!