### PR TITLE
✨[Feat] 전문가 포트폴리오 CRUD api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,9 @@ dependencies {
 
 	// 문자인증 api coolSMS
 	implementation 'net.nurigo:sdk:4.3.2'
+
+	// HTML 파싱 라이브러리
+	implementation 'org.jsoup:jsoup:1.15.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
@@ -70,6 +70,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // 전문가 경력 관련 에러
     EXPERT_CAREER_NOT_FOUND(HttpStatus.BAD_REQUEST, "EXPERT_CAREER4001", "해당 경력 아이디와 일치하는 경력이 존재하지 않습니다."),
 
+    // 전문가 포트폴리오 관련 에러
+    PORTFOLIO_NOT_FOUND(HttpStatus.BAD_REQUEST, "PORTFOLIO4001", "해당 포트폴리오 아이디와 일치하는 포트폴리오가 존재하지 않습니다."),
+
     // 채팅 메시지 타입
     MESSAGE_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "MESSAGE_TYPE4001", "지원되지 않는 채팅 메시지 타입입니다."),
 

--- a/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/backend/farmon/apiPayload/code/status/ErrorStatus.java
@@ -72,6 +72,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 전문가 포트폴리오 관련 에러
     PORTFOLIO_NOT_FOUND(HttpStatus.BAD_REQUEST, "PORTFOLIO4001", "해당 포트폴리오 아이디와 일치하는 포트폴리오가 존재하지 않습니다."),
+    PORTFOLIO_DELETE_FAILED(HttpStatus.BAD_REQUEST, "PORTFOLIO4002", "포트폴리오 삭제에 실패하였습니다."),
 
     // 채팅 메시지 타입
     MESSAGE_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "MESSAGE_TYPE4001", "지원되지 않는 채팅 메시지 타입입니다."),

--- a/src/main/java/com/backend/farmon/apiPayload/exception/handler/PortfolioHandler.java
+++ b/src/main/java/com/backend/farmon/apiPayload/exception/handler/PortfolioHandler.java
@@ -1,0 +1,10 @@
+package com.backend.farmon.apiPayload.exception.handler;
+
+import com.backend.farmon.apiPayload.code.BaseErrorCode;
+import com.backend.farmon.apiPayload.exception.GeneralException;
+
+public class PortfolioHandler extends GeneralException {
+    public PortfolioHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/backend/farmon/controller/ExpertController.java
+++ b/src/main/java/com/backend/farmon/controller/ExpertController.java
@@ -52,7 +52,7 @@ public class ExpertController {
 
     // 전문가 내 프로필 페이지 조회
     @GetMapping("/api/expert/{expert-id}")
-    @Operation(summary = "전문가 내 프로필 페이지 조회 API")
+    @Operation(summary = "전문가 내 프로필 페이지 조회 API", description = "isNickNameOnly(닉네임만 보이기 활성화 여부)가 true이면 name항목이 null값으로 반환됩니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
     })
@@ -224,14 +224,14 @@ public class ExpertController {
     @Operation(
             summary = "전문가 프로필 목록 조회 API",
             description = "전문가 프로필 목록을 조회하는 API이며, 페이징을 포함합니다. " +
-                    "서비스, 지역, 페이지를 query String 으로 주세요."
+                    "서비스, 지역, 페이지를 query String 으로 주세요. " + "isNickNameOnly(닉네임만 보이기 활성화 여부)가 true이면 name항목이 null값으로 반환됩니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
     })
     @Parameters({
-            @Parameter(name = "crop", description = "전문가 분야 필터링", required = false),
-            @Parameter(name = "area", description = "전문가 지역 필터링", required = false),
+            @Parameter(name = "crop", description = "전문가 분야 필터링", example = "옥수수", required = false),
+            @Parameter(name = "area", description = "전문가 지역 필터링", example = "경기전체", required = false),
             @Parameter(name = "page", description = "페이지 번호, 1부터 시작입니다.", example = "1", required = true)
     })
     public ApiResponse<ExpertListResponse.ExpertProfileListDTO> getExpertList (@RequestParam(name = "crop", required = false) String crop,
@@ -324,5 +324,21 @@ public class ExpertController {
         } catch (Exception e) {
             return ApiResponse.onFailure("ERROR_DELETE_PORTFOLIO","포트폴리오 삭제에 실패했습니다.",null);
         }
+    }
+
+    // 전문가 내 프로필 편집
+    @PatchMapping("/api/expert/{expert-id}/profile")
+    @Operation(summary = "전문가 내 프로필 편집 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameters({
+            @Parameter(name = "expert-id", description = "내 프로필을 변경하려는 전문가의 id", required = true),
+    })
+    public ApiResponse<ExpertProfileResponse.UpdateProfileResultDTO> updateExpertProfile(
+            @RequestBody ExpertProfileRequest.UpdateProfileDTO updateProfileDTO,
+            @PathVariable(name = "expert-id") Long expertId) {
+        Expert updatedExpert = expertCommandService.updateExpertProfile(expertId, updateProfileDTO);
+        return ApiResponse.onSuccess(ExpertConverter.updateProfileDTO(updatedExpert));
     }
 }

--- a/src/main/java/com/backend/farmon/controller/ExpertController.java
+++ b/src/main/java/com/backend/farmon/controller/ExpertController.java
@@ -281,4 +281,48 @@ public class ExpertController {
 
         return ApiResponse.onSuccess(ExpertConverter.toPortfolioGetResultDTO(portfolio));
     }
+
+    // 포트폴리오 수정 api
+    @PatchMapping(value = "/api/expert/portfolio/{portfolio-id}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @Operation(summary = "전문가 포트폴리오 수정 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<PortfolioResponse.PostPortfolioResultDTO> updatePortfolio(
+            @Parameter(description = "수정하려는 포트폴리오의 id", required = true)
+            @PathVariable(name = "portfolio-id") Long portfolioId,
+
+            @Parameter(description = "대표 이미지 변경 없을시 null값으로 보내주세요.", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                    schema = @Schema(type = "string", format = "binary")))
+            @RequestPart(value = "thumbnailImg", required = false) MultipartFile thumbnailImg,
+
+            @Parameter(description = "포트폴리오 등록 데이터", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PortfolioRequest.PostPortfolioDTO.class)))
+            @RequestPart("request") @Valid PortfolioRequest.PostPortfolioDTO postPortfolioDTO,
+
+            @Parameter(description = "추가된 이미지 파일만 넣어주세요.", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                    array = @ArraySchema(schema = @Schema(type = "string", format = "binary"))))
+            @RequestPart(value = "ImgList", required = false) List<MultipartFile> ImgList){
+
+        PortfolioResponse.PostPortfolioResultDTO resultDTO = expertCommandService.updatePortfolio(portfolioId, postPortfolioDTO, ImgList, thumbnailImg);
+
+        return ApiResponse.onSuccess(resultDTO);
+    }
+
+    // 전문가 특정 포트폴리오 삭제
+    @DeleteMapping("/api/expert/portfolio/{portfolio-id}")
+    @Operation(summary = "전문가 특정 포트폴리오 삭제 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @Parameters({
+            @Parameter(name = "portfolio-id", description = "삭제하려는 포트폴리오의 id", required = true)
+    })
+    public ApiResponse<String> deletePortfolio(@PathVariable(name = "portfolio-id") Long portfolioId) {
+        try {
+            expertCommandService.deletePortfolio(portfolioId);
+            return ApiResponse.onSuccess("포트폴리오가 성공적으로 삭제되었습니다.");
+        } catch (Exception e) {
+            return ApiResponse.onFailure("ERROR_DELETE_PORTFOLIO","포트폴리오 삭제에 실패했습니다.",null);
+        }
+    }
 }

--- a/src/main/java/com/backend/farmon/controller/ExpertController.java
+++ b/src/main/java/com/backend/farmon/controller/ExpertController.java
@@ -7,18 +7,23 @@ import com.backend.farmon.apiPayload.exception.handler.ExpertHandler;
 import com.backend.farmon.converter.ExpertConverter;
 import com.backend.farmon.domain.Expert;
 import com.backend.farmon.domain.ExpertCareer;
+import com.backend.farmon.domain.Portfolio;
 import com.backend.farmon.domain.User;
+import com.backend.farmon.dto.estimate.EstimateRequestDTO;
 import com.backend.farmon.dto.estimate.EstimateResponseDTO;
 import com.backend.farmon.dto.expert.*;
 import com.backend.farmon.repository.ExpertCareerRepository.ExpertCareerRepository;
 import com.backend.farmon.repository.ExpertReposiotry.ExpertRepository;
+import com.backend.farmon.repository.PortfolioRepository.PortfolioRepository;
 import com.backend.farmon.service.AWS.S3Service;
 import com.backend.farmon.service.ExpertService.ExpertCommandService;
 import com.backend.farmon.service.ExpertService.ExpertQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -29,6 +34,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Tag(name = "전문가 정보", description = "전문가 관련 정보 CRUD API")
 @RestController
@@ -41,6 +48,7 @@ public class ExpertController {
     private final ExpertRepository expertRepository;
     private final ExpertQueryService expertQueryService;
     private final S3Service s3Service;
+    private final PortfolioRepository portfolioRepository;
 
     // 전문가 내 프로필 페이지 조회
     @GetMapping("/api/expert/{expert-id}")
@@ -234,4 +242,43 @@ public class ExpertController {
         return ApiResponse.onSuccess(response);
     }
 
+    // 포트폴리오 등록 api
+    @PostMapping(value = "/api/expert/{expert-id}/portfolio", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @Operation(summary = "전문가 포트폴리오 등록 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<PortfolioResponse.PostPortfolioResultDTO> savePortfolio(
+            @Parameter(description = "포트폴리오를 등록하려는 전문가의 id", required = true)
+            @PathVariable(name = "expert-id") Long expertId,
+
+            @Parameter(description = "대표 이미지", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                    schema = @Schema(type = "string", format = "binary")))
+            @RequestPart("thumbnailImg") MultipartFile thumbnailImg,
+
+            @Parameter(description = "포트폴리오 등록 데이터", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = PortfolioRequest.PostPortfolioDTO.class)))
+            @RequestPart("request") @Valid PortfolioRequest.PostPortfolioDTO postPortfolioDTO,
+
+            @Parameter(description = "본문에 포함된 이미지 파일들. 이 파일들은 S3에 저장되며, 본문 내용에서 이미지 주소가 자동으로 S3 URL로 변환되어 저장됩니다.", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                    array = @ArraySchema(schema = @Schema(type = "string", format = "binary"))))
+            @RequestPart(value = "ImgList", required = false) List<MultipartFile> ImgList){
+
+        PortfolioResponse.PostPortfolioResultDTO resultDTO = expertCommandService.savePortfolio(expertId, postPortfolioDTO, ImgList, thumbnailImg);
+
+        return ApiResponse.onSuccess(resultDTO);
+    }
+
+    // 포트폴리오 조회 api
+    @GetMapping("/api/expert/portfolio/{portfolio-id}")
+    @Operation(summary = "전문가 특정 포트폴리오 조회 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    public ApiResponse<PortfolioResponse.PostPortfolioResultDTO> savePortfolio(
+            @PathVariable(name = "portfolio-id") Long portfolioId){
+        Portfolio portfolio = portfolioRepository.findById(portfolioId)
+                .orElseThrow(() -> new ExpertHandler(ErrorStatus.PORTFOLIO_NOT_FOUND));
+
+        return ApiResponse.onSuccess(ExpertConverter.toPortfolioGetResultDTO(portfolio));
+    }
 }

--- a/src/main/java/com/backend/farmon/converter/ExpertConverter.java
+++ b/src/main/java/com/backend/farmon/converter/ExpertConverter.java
@@ -223,4 +223,15 @@ public class ExpertConverter {
                 .detailContent4(expertCareer.getDetailContent4())
                 .build();
     }
+
+    // 전문가 포트폴리오 GET 응답 DTO 생성
+    public static PortfolioResponse.PostPortfolioResultDTO toPortfolioGetResultDTO(Portfolio portfolio) {
+        return PortfolioResponse.PostPortfolioResultDTO.builder()
+                .portfolioId(portfolio.getId())
+                .title(portfolio.getTitle())
+                .text(portfolio.getText())
+                .thumbnailImg(portfolio.getThumbnailImg())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/com/backend/farmon/converter/ExpertConverter.java
+++ b/src/main/java/com/backend/farmon/converter/ExpertConverter.java
@@ -130,6 +130,16 @@ public class ExpertConverter {
                 .build();
     }
 
+    // 전문가 내 프로필 수정 응답 DTO 생성
+    public static ExpertProfileResponse.UpdateProfileResultDTO updateProfileDTO(Expert request) {
+        return ExpertProfileResponse.UpdateProfileResultDTO.builder()
+                .expertId(request.getId())
+                .nickName(request.getNickName())
+                .isNickNameOnly(request.getIsNickNameOnly())
+                .expertDescription(request.getExpertDescription())
+                .build();
+    }
+
     // 전문가 프로필 리스트 조회
     public static ExpertListResponse.ExpertProfileListDTO expertProfileListDTO(Page<Expert> expertList) {
         List<ExpertListResponse.ExpertProfileViewDTO> expertProfileViewDTOList = expertList.stream()
@@ -150,7 +160,9 @@ public class ExpertConverter {
         return ExpertListResponse.ExpertProfileViewDTO.builder()
                 .expertId(expert.getId())
                 .profileImg(expert.getProfileImageUrl())
-                .name(expert.getUser().getUserName())
+                .name(expert.getIsNickNameOnly() ? null : expert.getUser().getUserName())
+                .nickName(expert.getNickName())
+                .isNickNameOnly(expert.getIsNickNameOnly())
                 .rate(expert.getRating())
                 .career(expert.getCareerYears())
                 .expertDescription(expert.getExpertDescription())
@@ -175,8 +187,9 @@ public class ExpertConverter {
 
         return ExpertProfileResponse.ExpertProfileDTO.builder()
                 .profileImg(expert.getProfileImageUrl())
-                .name(expert.getUser().getUserName())
-                 // .nickName(expert.getNickName)  닉네임 항목 추가시 수정
+                .name(expert.getIsNickNameOnly() ? null : expert.getUser().getUserName())
+                .nickName(expert.getNickName())
+                .isNickNameOnly(expert.getIsNickNameOnly())
                 .expertDescription(expert.getExpertDescription())
                 .rate(expert.getRating())
                 // .reviewCount() 리뷰 추가시 수정

--- a/src/main/java/com/backend/farmon/domain/Portfolio.java
+++ b/src/main/java/com/backend/farmon/domain/Portfolio.java
@@ -28,7 +28,8 @@ public class Portfolio extends BaseEntity {
     @Column(nullable = false)
     private String thumbnailImg;
 
-    @Column(nullable = false)
+    @Lob
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String text;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -36,5 +37,14 @@ public class Portfolio extends BaseEntity {
     private Expert expert;
 
     @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<PortfolioImg> portfolioImgList = new ArrayList<>();
+
+    public void setExpert(Expert expert) {
+        if (this.expert != null) {
+            expert.getPortfolioList().remove(this);
+        }
+        this.expert = expert;
+        expert.getPortfolioList().add(this);
+    }
 }

--- a/src/main/java/com/backend/farmon/domain/PortfolioImg.java
+++ b/src/main/java/com/backend/farmon/domain/PortfolioImg.java
@@ -28,4 +28,12 @@ public class PortfolioImg extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "portfolio_id")
     private Portfolio portfolio;
+
+    public void setPortfolio(Portfolio portfolio) {
+        if (this.portfolio != null) {
+            portfolio.getPortfolioImgList().remove(this);
+        }
+        this.portfolio = portfolio;
+        portfolio.getPortfolioImgList().add(this);
+    }
 }

--- a/src/main/java/com/backend/farmon/dto/expert/ExpertListResponse.java
+++ b/src/main/java/com/backend/farmon/dto/expert/ExpertListResponse.java
@@ -50,6 +50,12 @@ public class ExpertListResponse {
         @Schema(description = "이름")
         String name;
 
+        @Schema(description = "닉네임")
+        String nickName;
+
+        @Schema(description = "닉네임만 보여주기 여부")
+        Boolean isNickNameOnly;
+
         @Schema(description = "평점")
         Float rate;
 

--- a/src/main/java/com/backend/farmon/dto/expert/ExpertProfileRequest.java
+++ b/src/main/java/com/backend/farmon/dto/expert/ExpertProfileRequest.java
@@ -40,4 +40,17 @@ public class ExpertProfileRequest {
         @Schema(description = "도서 지방 제외 여부")
         Boolean isExcludeIsland;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateProfileDTO { // 내 프로필 변경 요청 DTO
+        @Schema(description = "닉네임", example = "해충해방")
+        String nickName;
+        @Schema(description = "닉네임만 보여주기 여부", example = "true")
+        Boolean isNickNameOnly;
+        @Schema(description = "한 줄 소개", example = "현장에서 쌓은 경험을 바탕으로, 실전 노하우를 전해드립니다.")
+        String expertDescription;
+    }
 }

--- a/src/main/java/com/backend/farmon/dto/expert/ExpertProfileResponse.java
+++ b/src/main/java/com/backend/farmon/dto/expert/ExpertProfileResponse.java
@@ -22,6 +22,12 @@ public class ExpertProfileResponse {
         @Schema(description = "이름")
         String name;
 
+        @Schema(description = "닉네임")
+        String nickName;
+
+        @Schema(description = "닉네임만 표시 여부")
+        Boolean isNickNameOnly;
+
         @Schema(description = "전문가 한 줄 소개")
         String expertDescription;
 
@@ -170,5 +176,22 @@ public class ExpertProfileResponse {
         Boolean isAvailableEverywhere;
         @Schema(description = "도서 지방 제외 여부")
         Boolean isExcludeIsland;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateProfileResultDTO { // 내 프로필 변경시 응답 DTO
+        @Schema(description = "전문가 아이디")
+        Long expertId;
+        @Schema(description = "닉네임")
+        String nickName;
+        @Schema(description = "닉네임만 보여주기 여부")
+        Boolean isNickNameOnly;
+        @Schema(description = "한 줄 소개")
+        String expertDescription;
+
+
     }
 }

--- a/src/main/java/com/backend/farmon/dto/expert/PortfolioRequest.java
+++ b/src/main/java/com/backend/farmon/dto/expert/PortfolioRequest.java
@@ -1,0 +1,28 @@
+package com.backend.farmon.dto.expert;
+
+import com.backend.farmon.domain.Expert;
+import com.backend.farmon.domain.PortfolioImg;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PortfolioRequest {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PostPortfolioDTO { // 포트폴리오 등록 요청 DTO
+        @Schema(description = "포트폴리오 제목", example = "무양 토양센서 컨설팅")
+        String title;
+        @Schema(description = "내용", example = "<h1>제목</h1>\n" +
+                "<p>여기에 <strong>강조된 텍스트</strong>가 포함되어 있습니다.</p>\n" +
+                "<img src=\"http://example.com/image.jpg\" alt=\"이미지\">\n")
+        String text;
+    }
+}

--- a/src/main/java/com/backend/farmon/dto/expert/PortfolioResponse.java
+++ b/src/main/java/com/backend/farmon/dto/expert/PortfolioResponse.java
@@ -31,4 +31,14 @@ public class PortfolioResponse {
         LocalDateTime createdAt;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "전문가 포트폴리오 삭제 DTO")
+    public static class DeletePortfolioResultDTO {
+        @Schema(description = "삭제된 포트폴리오 아이디")
+        Long portfolioId;
+    }
+
 }

--- a/src/main/java/com/backend/farmon/dto/expert/PortfolioResponse.java
+++ b/src/main/java/com/backend/farmon/dto/expert/PortfolioResponse.java
@@ -1,0 +1,34 @@
+package com.backend.farmon.dto.expert;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class PortfolioResponse {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "전문가 포트폴리오 응답 DTO")
+    public static class PostPortfolioResultDTO {
+        @Schema(description = "생성된 포트폴리오 아이디")
+        Long portfolioId;
+
+        @Schema(description = "포트폴리오 제목")
+        String title;
+
+        @Schema(description = "내용")
+        String text;
+
+        @Schema(description = "대표 이미지")
+        String thumbnailImg;
+
+        @Schema(description = "생성시간")
+        LocalDateTime createdAt;
+    }
+
+}

--- a/src/main/java/com/backend/farmon/repository/PortfolioImgRepository/PortfolioImgRepository.java
+++ b/src/main/java/com/backend/farmon/repository/PortfolioImgRepository/PortfolioImgRepository.java
@@ -1,0 +1,7 @@
+package com.backend.farmon.repository.PortfolioImgRepository;
+
+import com.backend.farmon.domain.PortfolioImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PortfolioImgRepository extends JpaRepository<PortfolioImg, Long> {
+}

--- a/src/main/java/com/backend/farmon/repository/PortfolioRepository/PortfolioRepository.java
+++ b/src/main/java/com/backend/farmon/repository/PortfolioRepository/PortfolioRepository.java
@@ -1,0 +1,9 @@
+package com.backend.farmon.repository.PortfolioRepository;
+
+import com.backend.farmon.domain.Portfolio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+}

--- a/src/main/java/com/backend/farmon/service/AWS/S3Service.java
+++ b/src/main/java/com/backend/farmon/service/AWS/S3Service.java
@@ -123,7 +123,6 @@ public class S3Service {
         amazonS3.deleteObject(bucket, img.getStoredFileName());
     }
 
-
     // 전문가 프로필 이미지
     @Transactional
     public String putProfImage(Long expertId, MultipartFile multipartFile) throws IOException {
@@ -148,7 +147,10 @@ public class S3Service {
 
         // 이전에 저장된 프로필 사진이 있으면 삭제
         if (expert.getProfileImageUrl() != null){
-            deleteProfImage(expertId);
+            String profileUrl = expert.getProfileImageUrl();
+            String s3key = profileUrl.substring(profileUrl.indexOf("Profile/"));
+            deleteImg(s3key);
+            expert.setProfileImageUrl(null);
         }
 
         // 원본 파일명을 서버에 저장된 파일명으로 변경하여 storedFileName에 저장하기 위함 (중복 비허용)
@@ -163,24 +165,6 @@ public class S3Service {
 
         expert.setProfileImageUrl(getFullPath(storedFileName));
         return getFullPath(storedFileName);
-    }
-//
-//    // 프로필 이미지의 S3 전체 주소 조회
-//    @Transactional(readOnly = true)
-//    public String getProfImage(Long userNo){
-//        User user = userRepository.findById(userNo).orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다"));
-//        if (user.getUserProfImg() == null){
-//            return null;
-//        }
-//        return getFullPath(user.getUserProfImg());
-//    }
-
-    // 프로필 이미지 삭제
-    @Transactional
-    public void deleteProfImage(Long expertId)  {
-        Expert expert = expertRepository.findById(expertId).orElseThrow(() -> new ExpertHandler(ErrorStatus.EXPERT_NOT_FOUND));
-        amazonS3.deleteObject(bucket, expert.getProfileImageUrl());
-        expert.setProfileImageUrl(null);
     }
 
     // 채팅용 이미지 업로드
@@ -213,5 +197,38 @@ public class S3Service {
         amazonS3.putObject(bucket, storedFileName, multipartFile.getInputStream(), metadata);
 
         return getFullPath(storedFileName);
+    }
+
+    // 포트폴리오 이미지 저장
+    @Transactional
+    public String putPortfolioImg(MultipartFile multipartFile) {
+        if (multipartFile.isEmpty()) {return null;}
+
+        List<String> allowedExtensions = Arrays.asList("jpg", "jpeg", "png", "gif", "webp");
+        String originalFileName = multipartFile.getOriginalFilename();
+        String fileExtension = extractExt(originalFileName).toLowerCase();
+
+        if (!allowedExtensions.contains(fileExtension)) {
+            throw new IllegalArgumentException("지원하지 않는 파일 형식입니다. 이미지 파일(jpg, jpeg, png, gif, webp)만 업로드 가능합니다.");
+        }
+
+        String storedFileName = "Portfolio/" + UUID.randomUUID() + "." + extractExt(originalFileName);
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        metadata.setContentType(multipartFile.getContentType());
+        try {
+            amazonS3.putObject(bucket, storedFileName, multipartFile.getInputStream(), metadata);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return getFullPath(storedFileName);
+    }
+
+    // 이미지 삭제
+    @Transactional
+    public void deleteImg(String imgUrl)  {
+        amazonS3.deleteObject(bucket, imgUrl);
     }
 }

--- a/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandService.java
+++ b/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandService.java
@@ -21,4 +21,8 @@ public interface ExpertCommandService {
     PortfolioResponse.PostPortfolioResultDTO savePortfolio(Long expertId, PortfolioRequest.PostPortfolioDTO postPortfolioDTO,
                                                            List<MultipartFile> ImgList, MultipartFile thumbnailImg);
     String updateTextWithImageUrls(String text, List<PortfolioImg> imageUrls);
+    PortfolioResponse.PostPortfolioResultDTO updatePortfolio(Long expertId, PortfolioRequest.PostPortfolioDTO postPortfolioDTO,
+                                                             List<MultipartFile> ImgList, MultipartFile thumbnailImg);
+    String updateImageSrcWithS3(String text, List<PortfolioImg> newImageUrls);
+    PortfolioResponse.DeletePortfolioResultDTO deletePortfolio(Long portfolioId);
 }

--- a/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandService.java
+++ b/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandService.java
@@ -2,14 +2,23 @@ package com.backend.farmon.service.ExpertService;
 
 import com.backend.farmon.domain.Expert;
 import com.backend.farmon.domain.ExpertCareer;
+import com.backend.farmon.domain.PortfolioImg;
 import com.backend.farmon.dto.expert.ExpertCareerRequest;
 import com.backend.farmon.dto.expert.ExpertProfileRequest;
+import com.backend.farmon.dto.expert.PortfolioRequest;
+import com.backend.farmon.dto.expert.PortfolioResponse;
 import com.backend.farmon.dto.user.SignupRequest;
 import com.backend.farmon.dto.user.SignupResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 public interface ExpertCommandService {
     SignupResponse.ExpertJoinResultDTO joinExpert(Long userId, SignupRequest.ExpertJoinDto request);
     ExpertCareer postExpertCareer(Long expertId, ExpertCareerRequest.ExpertCareerPostDTO request);
     Expert updateExpertSpecialty(Long expertId, ExpertProfileRequest.UpdateSpecialtyDTO request);
     Expert updateExpertArea(Long expertId, ExpertProfileRequest.UpdateAreaDTO request);
+    PortfolioResponse.PostPortfolioResultDTO savePortfolio(Long expertId, PortfolioRequest.PostPortfolioDTO postPortfolioDTO,
+                                                           List<MultipartFile> ImgList, MultipartFile thumbnailImg);
+    String updateTextWithImageUrls(String text, List<PortfolioImg> imageUrls);
 }

--- a/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandService.java
+++ b/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandService.java
@@ -18,6 +18,7 @@ public interface ExpertCommandService {
     ExpertCareer postExpertCareer(Long expertId, ExpertCareerRequest.ExpertCareerPostDTO request);
     Expert updateExpertSpecialty(Long expertId, ExpertProfileRequest.UpdateSpecialtyDTO request);
     Expert updateExpertArea(Long expertId, ExpertProfileRequest.UpdateAreaDTO request);
+    Expert updateExpertProfile(Long expertId, ExpertProfileRequest.UpdateProfileDTO request);
     PortfolioResponse.PostPortfolioResultDTO savePortfolio(Long expertId, PortfolioRequest.PostPortfolioDTO postPortfolioDTO,
                                                            List<MultipartFile> ImgList, MultipartFile thumbnailImg);
     String updateTextWithImageUrls(String text, List<PortfolioImg> imageUrls);

--- a/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandServiceImpl.java
@@ -17,10 +17,16 @@ import com.backend.farmon.repository.AreaRepository.AreaRepository;
 import com.backend.farmon.repository.CropRepository.CropRepository;
 import com.backend.farmon.repository.ExpertCareerRepository.ExpertCareerRepository;
 import com.backend.farmon.repository.ExpertReposiotry.ExpertRepository;
+import com.backend.farmon.repository.PortfolioImgRepository.PortfolioImgRepository;
 import com.backend.farmon.repository.PortfolioRepository.PortfolioRepository;
 import com.backend.farmon.repository.UserRepository.UserRepository;
 import com.backend.farmon.service.AWS.S3Service;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,7 +36,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ExpertCommandServiceImpl implements ExpertCommandService {
@@ -43,6 +51,7 @@ public class ExpertCommandServiceImpl implements ExpertCommandService {
     private final UserAuthorizationUtil userAuthorizationUtil;
     private final S3Service s3Service;
     private final PortfolioRepository portfolioRepository;
+    private final PortfolioImgRepository portfolioImgRepository;
 
     // 전문가 등록 로직
     @Override
@@ -165,7 +174,6 @@ public class ExpertCommandServiceImpl implements ExpertCommandService {
         newPortfolio.setText(updatedText); // 수정된 본문 텍스트 저장
 
         // 6. 포트폴리오와 이미지들을 DB에 저장
-//        newPortfolio.setPortfolioImgList(portfolioImgs);
         Portfolio savedPortfolio = portfolioRepository.save(newPortfolio);
 
         // 7. 결과 반환
@@ -173,33 +181,116 @@ public class ExpertCommandServiceImpl implements ExpertCommandService {
     }
 
     public String updateTextWithImageUrls(String text, List<PortfolioImg> imageUrls) {
-        // 본문 텍스트에서 이미지 태그를 찾아서 S3 URL로 변경
-        StringBuilder updatedText = new StringBuilder(text);
+        // HTML 텍스트를 JSoup으로 파싱
+        Document doc = Jsoup.parse(text);
+
+        // 모든 <img> 태그를 가져오기
+        Elements imgTags = doc.select("img");
+
+        // 이미지 태그 교체
         int imageIndex = 0;
-
-        // 이미지 태그를 찾기 위한 정규 표현식 패턴 정의
-        // <img> 태그에서 src 속성만을 추출하는 패턴
-        Pattern pattern = Pattern.compile("<img[^>]*src=['\"](http[^\"]*)['\"][^>]*>");
-
-        // text에서 패턴에 맞는 부분을 찾을 수 있는 Matcher 객체 생성
-        Matcher matcher = pattern.matcher(updatedText);
-
-        // 텍스트 내의 모든 이미지 태그를 순차적으로 찾아서 교체
-        while (matcher.find() && imageIndex < imageUrls.size()) {
-            // 현재 이미지 URL을 imageUrls 리스트에서 가져옴
-            String s3Url = imageUrls.get(imageIndex).getImageUrl();
-
-            // 이미지 태그를 기존 src URL에서 S3 URL로 교체
-            // 예) <img src="http://example.com/old-image.jpg">를 <img src="s3://bucket/path/image.jpg">로 교체
-            updatedText.replace(matcher.start(), matcher.end(), "<img src=\"" + s3Url + "\">");
-
-            // imageUrls 리스트에서 다음 이미지를 사용할 수 있도록 인덱스 증가
-            imageIndex++;
+        for (Element imgTag : imgTags) {
+            if (imageIndex < imageUrls.size()) {
+                // 현재 이미지 URL을 imageUrls 리스트에서 가져옴
+                String s3Url = imageUrls.get(imageIndex).getImageUrl();
+                imgTag.attr("src", s3Url);  // src 속성을 새 URL로 교체
+                imageIndex++;
+            }
         }
 
-
-        return updatedText.toString();
+        // 변경된 HTML을 문자열로 반환
+        return doc.html();
     }
 
+    // 포트폴리오 등록 서비스
+    public PortfolioResponse.PostPortfolioResultDTO updatePortfolio(Long portfolioId, PortfolioRequest.PostPortfolioDTO postPortfolioDTO,
+                                                                  List<MultipartFile> ImgList, MultipartFile thumbnailImg) {
+        Portfolio portfolio = portfolioRepository.findById(portfolioId)
+                .orElseThrow(() -> new ExpertHandler(ErrorStatus.PORTFOLIO_NOT_FOUND));
 
+        // 1. 썸네일 이미지 수정
+        if(thumbnailImg != null){
+            // 기존 이미지 S3에서 삭제
+            String thumbnailUrl = portfolio.getThumbnailImg();
+            String s3key = thumbnailUrl.substring(thumbnailUrl.indexOf("Portfolio/"));
+            s3Service.deleteImg(s3key);
+
+            String thumbnailImgUrl = s3Service.putPortfolioImg(thumbnailImg);
+            portfolio.setThumbnailImg(thumbnailImgUrl);
+        }
+
+        // 2. 제목 수정
+        portfolio.setTitle(postPortfolioDTO.getTitle());
+
+        // 3. 새로운 본문 이미지도 추가된 경우
+        if(ImgList != null){
+            // 새로운 이미지 파일 처리
+            List<PortfolioImg> portfolioImgs = new ArrayList<>();
+            for (MultipartFile img : ImgList) {
+                String s3ImageUrl = s3Service.putPortfolioImg(img);
+                PortfolioImg portfolioImg = PortfolioImg.builder() // 포트폴리오 이미지 엔티티 생성
+                        .imageUrl(s3ImageUrl)
+                        .build();
+                portfolioImg.setPortfolio(portfolio); // 포트폴리오 엔티티와 양방매핑
+                portfolioImgs.add(portfolioImg);
+            }
+            portfolioImgRepository.saveAll(portfolioImgs);
+
+            // 본문 이미지 URL 수정
+            String updatedText = updateImageSrcWithS3(postPortfolioDTO.getText(), portfolioImgs);
+            portfolio.setText(updatedText); // 수정된 본문 텍스트 저장
+        }else{ // 4. 텍스트만 바뀐 경우
+            portfolio.setText(postPortfolioDTO.getText());
+        }
+        portfolioRepository.save(portfolio);
+        // 결과 반환
+        return ExpertConverter.toPortfolioGetResultDTO(portfolio);
+    }
+
+    public String updateImageSrcWithS3(String text, List<PortfolioImg> newImageUrls) {
+        int imageIndex = 0;
+        Document document = Jsoup.parse(text);
+
+        for (Element img : document.select("img")) {
+            String src = img.attr("src");
+
+            if (!src.startsWith("https://umcfarmon.s3.ap-northeast-2.amazonaws.com") && imageIndex < newImageUrls.size()) {
+                img.attr("src", newImageUrls.get(imageIndex).getImageUrl());
+                imageIndex++;
+            }
+        }
+        return document.html();
+    }
+
+    // 포트폴리오 삭제 서비스
+    public PortfolioResponse.DeletePortfolioResultDTO deletePortfolio(Long portfolioId){
+        Portfolio portfolio = portfolioRepository.findById(portfolioId)
+                .orElseThrow(() -> new PortfolioHandler(ErrorStatus.PORTFOLIO_NOT_FOUND));
+
+        try {
+            // 썸네일 이미지 s3에서 삭제
+            String thumbnailUrl = portfolio.getThumbnailImg();
+            String s3key = thumbnailUrl.substring(thumbnailUrl.indexOf("Portfolio/"));
+            s3Service.deleteImg(s3key);
+
+            // 본문 이미지 s3에서 삭제
+            List<String> imgUrls = portfolio.getPortfolioImgList().stream()
+                    .map(PortfolioImg::getImageUrl)
+                    .collect(Collectors.toList());
+
+            for (String imgUrl : imgUrls) {
+                String s3url = imgUrl.substring(imgUrl.indexOf("Portfolio/"));
+                s3Service.deleteImg(s3url);
+            }
+
+            // 포트폴리오 삭제
+            portfolioRepository.delete(portfolio);
+
+            return PortfolioResponse.DeletePortfolioResultDTO.builder()
+                    .portfolioId(portfolioId)
+                    .build();
+        } catch (Exception e) {
+            throw new PortfolioHandler(ErrorStatus.PORTFOLIO_DELETE_FAILED);
+        }
+    }
 }

--- a/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandServiceImpl.java
@@ -9,16 +9,27 @@ import com.backend.farmon.domain.*;
 import com.backend.farmon.domain.enums.Role;
 import com.backend.farmon.dto.expert.ExpertCareerRequest;
 import com.backend.farmon.dto.expert.ExpertProfileRequest;
+import com.backend.farmon.dto.expert.PortfolioRequest;
+import com.backend.farmon.dto.expert.PortfolioResponse;
 import com.backend.farmon.dto.user.SignupRequest;
 import com.backend.farmon.dto.user.SignupResponse;
 import com.backend.farmon.repository.AreaRepository.AreaRepository;
 import com.backend.farmon.repository.CropRepository.CropRepository;
 import com.backend.farmon.repository.ExpertCareerRepository.ExpertCareerRepository;
 import com.backend.farmon.repository.ExpertReposiotry.ExpertRepository;
+import com.backend.farmon.repository.PortfolioRepository.PortfolioRepository;
 import com.backend.farmon.repository.UserRepository.UserRepository;
+import com.backend.farmon.service.AWS.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +41,8 @@ public class ExpertCommandServiceImpl implements ExpertCommandService {
     private final CropRepository cropRepository;
     private final ExpertCareerRepository expertCareerRepository;
     private final UserAuthorizationUtil userAuthorizationUtil;
+    private final S3Service s3Service;
+    private final PortfolioRepository portfolioRepository;
 
     // 전문가 등록 로직
     @Override
@@ -117,4 +130,76 @@ public class ExpertCommandServiceImpl implements ExpertCommandService {
 
         return expertRepository.save(expert);
     }
+
+    // 포트폴리오 등록 서비스
+    public PortfolioResponse.PostPortfolioResultDTO savePortfolio(Long expertId, PortfolioRequest.PostPortfolioDTO postPortfolioDTO,
+                                                                      List<MultipartFile> ImgList, MultipartFile thumbnailImg) {
+        // 1. 썸네일 이미지 업로드
+        String thumbnailImgUrl = s3Service.putPortfolioImg(thumbnailImg);
+
+        // 2. 포트폴리오 엔티티 생성
+        Portfolio newPortfolio = Portfolio.builder()
+                .thumbnailImg(thumbnailImgUrl)
+                .title(postPortfolioDTO.getTitle())
+                .text("")
+                .build();
+
+        // 3. 전문가와 매핑
+        Expert expert = expertRepository.findById(expertId)
+                .orElseThrow(() -> new ExpertHandler(ErrorStatus.EXPERT_NOT_FOUND));
+        newPortfolio.setExpert(expert);
+
+        // 4. 포트폴리오 이미지 처리 (이미지 파일 리스트)
+        List<PortfolioImg> portfolioImgs = new ArrayList<>();
+        for (MultipartFile img : ImgList) {
+            String s3ImageUrl = s3Service.putPortfolioImg(img);
+            PortfolioImg portfolioImg = PortfolioImg.builder() // 포트폴리오 이미지 엔티티 생성
+                    .imageUrl(s3ImageUrl)
+                    .build();
+            portfolioImg.setPortfolio(newPortfolio); // 포트폴리오 엔티티와 양방매핑
+            portfolioImgs.add(portfolioImg);
+        }
+
+        // 5. 본문 이미지 URL 수정
+        String updatedText = updateTextWithImageUrls(postPortfolioDTO.getText(), portfolioImgs);
+        newPortfolio.setText(updatedText); // 수정된 본문 텍스트 저장
+
+        // 6. 포트폴리오와 이미지들을 DB에 저장
+//        newPortfolio.setPortfolioImgList(portfolioImgs);
+        Portfolio savedPortfolio = portfolioRepository.save(newPortfolio);
+
+        // 7. 결과 반환
+        return ExpertConverter.toPortfolioGetResultDTO(savedPortfolio);
+    }
+
+    public String updateTextWithImageUrls(String text, List<PortfolioImg> imageUrls) {
+        // 본문 텍스트에서 이미지 태그를 찾아서 S3 URL로 변경
+        StringBuilder updatedText = new StringBuilder(text);
+        int imageIndex = 0;
+
+        // 이미지 태그를 찾기 위한 정규 표현식 패턴 정의
+        // <img> 태그에서 src 속성만을 추출하는 패턴
+        Pattern pattern = Pattern.compile("<img[^>]*src=['\"](http[^\"]*)['\"][^>]*>");
+
+        // text에서 패턴에 맞는 부분을 찾을 수 있는 Matcher 객체 생성
+        Matcher matcher = pattern.matcher(updatedText);
+
+        // 텍스트 내의 모든 이미지 태그를 순차적으로 찾아서 교체
+        while (matcher.find() && imageIndex < imageUrls.size()) {
+            // 현재 이미지 URL을 imageUrls 리스트에서 가져옴
+            String s3Url = imageUrls.get(imageIndex).getImageUrl();
+
+            // 이미지 태그를 기존 src URL에서 S3 URL로 교체
+            // 예) <img src="http://example.com/old-image.jpg">를 <img src="s3://bucket/path/image.jpg">로 교체
+            updatedText.replace(matcher.start(), matcher.end(), "<img src=\"" + s3Url + "\">");
+
+            // imageUrls 리스트에서 다음 이미지를 사용할 수 있도록 인덱스 증가
+            imageIndex++;
+        }
+
+
+        return updatedText.toString();
+    }
+
+
 }

--- a/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandServiceImpl.java
@@ -140,7 +140,23 @@ public class ExpertCommandServiceImpl implements ExpertCommandService {
         return expertRepository.save(expert);
     }
 
+    // 전문가 내 프로필 변경 로직
+    @Override
+    @Transactional
+    public Expert updateExpertProfile(Long expertId, ExpertProfileRequest.UpdateProfileDTO request) {
+        Expert expert = expertRepository.findById(expertId)
+                .orElseThrow(() -> new ExpertHandler(ErrorStatus.EXPERT_NOT_FOUND));
+
+        if (request.getNickName() != null) {expert.setNickName(request.getNickName());}
+        if (request.getIsNickNameOnly() != null) {expert.setIsNickNameOnly(request.getIsNickNameOnly());}
+        if (request.getExpertDescription() != null) {expert.setExpertDescription(request.getExpertDescription());}
+
+        return expertRepository.save(expert);
+    }
+
     // 포트폴리오 등록 서비스
+    @Override
+    @Transactional
     public PortfolioResponse.PostPortfolioResultDTO savePortfolio(Long expertId, PortfolioRequest.PostPortfolioDTO postPortfolioDTO,
                                                                       List<MultipartFile> ImgList, MultipartFile thumbnailImg) {
         // 1. 썸네일 이미지 업로드
@@ -180,6 +196,8 @@ public class ExpertCommandServiceImpl implements ExpertCommandService {
         return ExpertConverter.toPortfolioGetResultDTO(savedPortfolio);
     }
 
+    @Override
+    @Transactional
     public String updateTextWithImageUrls(String text, List<PortfolioImg> imageUrls) {
         // HTML 텍스트를 JSoup으로 파싱
         Document doc = Jsoup.parse(text);
@@ -203,6 +221,8 @@ public class ExpertCommandServiceImpl implements ExpertCommandService {
     }
 
     // 포트폴리오 등록 서비스
+    @Override
+    @Transactional
     public PortfolioResponse.PostPortfolioResultDTO updatePortfolio(Long portfolioId, PortfolioRequest.PostPortfolioDTO postPortfolioDTO,
                                                                   List<MultipartFile> ImgList, MultipartFile thumbnailImg) {
         Portfolio portfolio = portfolioRepository.findById(portfolioId)
@@ -247,6 +267,8 @@ public class ExpertCommandServiceImpl implements ExpertCommandService {
         return ExpertConverter.toPortfolioGetResultDTO(portfolio);
     }
 
+    @Override
+    @Transactional
     public String updateImageSrcWithS3(String text, List<PortfolioImg> newImageUrls) {
         int imageIndex = 0;
         Document document = Jsoup.parse(text);
@@ -263,6 +285,8 @@ public class ExpertCommandServiceImpl implements ExpertCommandService {
     }
 
     // 포트폴리오 삭제 서비스
+    @Override
+    @Transactional
     public PortfolioResponse.DeletePortfolioResultDTO deletePortfolio(Long portfolioId){
         Portfolio portfolio = portfolioRepository.findById(portfolioId)
                 .orElseThrow(() -> new PortfolioHandler(ErrorStatus.PORTFOLIO_NOT_FOUND));


### PR DESCRIPTION
## #️⃣연관된 이슈

> #143 

## 📝작업 내용

전문가 포트폴리오 CRUD api 구현하였습니다. application.yml파일 변경되었으니 노션에서 복붙하고 돌려주세요!


![image](https://github.com/user-attachments/assets/a117c4da-543f-4fd5-a749-c3c9da2ec27e)
본문 html과 포함된 이미지들을 함께 전송하면 
 
![image](https://github.com/user-attachments/assets/f8d9bb18-1dab-4948-9a37-26bcf42575b5)
본문 내용에서 이미지 주소가 자동으로 S3 URL로 변환되어 저장됩니다.


## 💬리뷰 요구사항(선택)

> 피드백 편하게 주세요!