### PR TITLE
✨ Feat: 아이디/비밀번호 찾기 api구현, 전문가 포트폴리오 등록 api 수정

### DIFF
--- a/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
+++ b/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig { // 애플리케이션의 보안 정책을 정의
 //                        .requestMatchers("/").authenticated()
 
                         // 공용 접근 허용 (누구나 접근 가능)
-                        .requestMatchers("/api/login","/api/generate","/api/verify","/api/user/join", "/api/home/community", "/api/home/popular",
+                        .requestMatchers("/api/login","/api/generate","/api/verify","/api/user/join", "/api/user/find-username", "/api/user/reset-password",
+                                "/api/home/community", "/api/home/popular",
                                 "/api/expert/list", "/api/expert/{expert-id}",
                                 "/api/posts/popular/list/**", "/api/posts/all/list/**", "/api/posts/free/list/**","/api/posts/qna/list/**",
                                 "/api/posts/expertCol/list/**", "/api/posts/{postId}/comments",

--- a/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
+++ b/src/main/java/com/backend/farmon/config/security/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig { // 애플리케이션의 보안 정책을 정의
 //                        .requestMatchers("/").authenticated()
 
                         // 공용 접근 허용 (누구나 접근 가능)
-                        .requestMatchers("/api/login","/api/generate","/api/verify","/api/user/join", "/api/user/find-username", "/api/user/reset-password",
+                        .requestMatchers("/api/login","/api/generate","/api/verify","/api/user/join", "/api/user/find-email", "/api/user/reset-password",
                                 "/api/home/community", "/api/home/popular",
                                 "/api/expert/list", "/api/expert/{expert-id}",
                                 "/api/posts/popular/list/**", "/api/posts/all/list/**", "/api/posts/free/list/**","/api/posts/qna/list/**",

--- a/src/main/java/com/backend/farmon/controller/UserController.java
+++ b/src/main/java/com/backend/farmon/controller/UserController.java
@@ -120,7 +120,7 @@ public class UserController {
         return ApiResponse.onSuccess(response);
     }
 
-    @PostMapping("/api/user/find-username")
+    @PostMapping("/api/user/find-email")
     @Operation(summary = "아이디(이메일) 찾기 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")

--- a/src/main/java/com/backend/farmon/controller/UserController.java
+++ b/src/main/java/com/backend/farmon/controller/UserController.java
@@ -9,6 +9,7 @@ import com.backend.farmon.config.security.UserAuthorizationUtil;
 import com.backend.farmon.converter.ExpertConverter;
 import com.backend.farmon.converter.SignupConverter;
 import com.backend.farmon.converter.UserConverter;
+import com.backend.farmon.domain.Expert;
 import com.backend.farmon.domain.User;
 import com.backend.farmon.domain.enums.Role;
 import com.backend.farmon.dto.user.ExchangeResponse;
@@ -117,5 +118,43 @@ public class UserController {
         ExchangeResponse response = userQueryService.exchangeRole(userId, role, token);
 
         return ApiResponse.onSuccess(response);
+    }
+
+    @PostMapping("/api/user/find-username")
+    @Operation(summary = "아이디(이메일) 찾기 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "phoneNum", description = "아이디를 찾으려는 유저의 휴대폰 번호", required = true)
+    })
+    public ApiResponse<String> findEmail(
+            @RequestParam(name="phoneNum") String phoneNum
+    ) {
+        User user = userRepository.findByPhoneNum(phoneNum)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        return ApiResponse.onSuccess(user.getEmail());
+    }
+
+    @PatchMapping("/api/user/reset-password")
+    @Operation(summary = "비밀번호 재설정 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공")
+    })
+    @Parameters({
+            @Parameter(name = "email", description = "비밀번호를 찾으려는 유저의 이메일(아이디)", required = true),
+            @Parameter(name = "newPassword", description = "재설정할 새로운 비밀번호", required = true)
+    })
+    public ApiResponse<String> resetPassword(
+            @RequestParam(name="email") String email,
+            @RequestParam(name="newPassword")  String newPassword
+    ) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        user.encodePassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+        return ApiResponse.onSuccess("비밀번호 변경이 완료되었습니다.");
     }
 }

--- a/src/main/java/com/backend/farmon/repository/UserRepository/UserRepository.java
+++ b/src/main/java/com/backend/farmon/repository/UserRepository/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     Optional<User> findByEmail(String email);
     boolean existsByPhoneNum(String phoneNum);
     Optional<User> findById(Long id);
+    Optional<User> findByPhoneNum(String phoneNumber);
 }

--- a/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandServiceImpl.java
@@ -175,19 +175,22 @@ public class ExpertCommandServiceImpl implements ExpertCommandService {
         newPortfolio.setExpert(expert);
 
         // 4. 포트폴리오 이미지 처리 (이미지 파일 리스트)
-        List<PortfolioImg> portfolioImgs = new ArrayList<>();
-        for (MultipartFile img : ImgList) {
-            String s3ImageUrl = s3Service.putPortfolioImg(img);
-            PortfolioImg portfolioImg = PortfolioImg.builder() // 포트폴리오 이미지 엔티티 생성
-                    .imageUrl(s3ImageUrl)
-                    .build();
-            portfolioImg.setPortfolio(newPortfolio); // 포트폴리오 엔티티와 양방매핑
-            portfolioImgs.add(portfolioImg);
+        if(ImgList != null) {
+            List<PortfolioImg> portfolioImgs = new ArrayList<>();
+            for (MultipartFile img : ImgList) {
+                String s3ImageUrl = s3Service.putPortfolioImg(img);
+                PortfolioImg portfolioImg = PortfolioImg.builder() // 포트폴리오 이미지 엔티티 생성
+                        .imageUrl(s3ImageUrl)
+                        .build();
+                portfolioImg.setPortfolio(newPortfolio); // 포트폴리오 엔티티와 양방매핑
+                portfolioImgs.add(portfolioImg);
+            }
+            // 5. 본문 이미지 URL 수정
+            String updatedText = updateTextWithImageUrls(postPortfolioDTO.getText(), portfolioImgs);
+            newPortfolio.setText(updatedText); // 수정된 본문 텍스트 저장
+        }else{ // 4. 본문 이미지 URL 없는 경우
+            newPortfolio.setText(postPortfolioDTO.getText());
         }
-
-        // 5. 본문 이미지 URL 수정
-        String updatedText = updateTextWithImageUrls(postPortfolioDTO.getText(), portfolioImgs);
-        newPortfolio.setText(updatedText); // 수정된 본문 텍스트 저장
 
         // 6. 포트폴리오와 이미지들을 DB에 저장
         Portfolio savedPortfolio = portfolioRepository.save(newPortfolio);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #143, #151 

## 📝작업 내용

아이디 찾기 api와 비밀번호 재설정 api 구현하였습니다. 
두 api 모두 로그인 전단계에 호출하는 api라, SecurityConfig 비로그인 접근 가능 api에 추가해놓았습니다!
그리고 포트폴리오 등록 api 본문 이미지리스트를 추가하지 않으면 실행되지 않는 에러가 있어서 수정하였습니다.

+그리고 노션 application.yml파일에 요청파일 최대용량 변경하는 설정 추가해놓았는데 누락된것 같아서 다시 추가해놓았습니다...!
노션 한 번만 다시 확인해주시면 감사하겠습니다!

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 편하게 피드백 주세요!