### PR TITLE
🐛 [Fix] 휴대폰 인증문자 전송 오류 수정

### DIFF
--- a/src/main/java/com/backend/farmon/domain/SmsAuth.java
+++ b/src/main/java/com/backend/farmon/domain/SmsAuth.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @DynamicUpdate
 @DynamicInsert
 @Builder

--- a/src/main/java/com/backend/farmon/service/SmsService/SmsServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/SmsService/SmsServiceImpl.java
@@ -49,27 +49,30 @@ public class SmsServiceImpl implements SmsService {
         if (userRepository.existsByPhoneNum(phoneNum)) {
             throw new UserHandler(ErrorStatus.PHONENUM_ALREADY_EXIST);  // 전화번호가 이미 존재할 경우 예외 발생
         }
-        // 기존 인증있으면(인증문자 재발급일 경우) 해당 엔티티 삭제
-        smsAuthRepository.findByPhoneNum(phoneNum)
-                .ifPresent(smsAuthRepository::delete);
+
+        // 새 인증 코드 생성
+        String certificationCode = Integer.toString((int)(Math.random() * (999999 - 100000 + 1)) + 100000); // 6자리 인증 코드를 랜덤으로 생성
+
+        // 기존 인증 정보를 업데이트하거나 없으면 새로 생성
+        SmsAuth newSmsAuth = smsAuthRepository.findByPhoneNum(phoneNum)
+                .map(existingAuth -> { // 기존 인증 정보가 있으면 업데이트
+                    existingAuth.setAuthCode(certificationCode);
+                    existingAuth.setExpirationTime(LocalDateTime.now().plusMinutes(3));
+                    return existingAuth;
+                })
+                .orElseGet(() -> SmsAuth.builder() // 기존 데이터가 없으면 새로 생성
+                        .phoneNum(phoneNum)
+                        .authCode(certificationCode)
+                        .expirationTime(LocalDateTime.now().plusMinutes(3))
+                        .build()
+                );
+        smsAuthRepository.save(newSmsAuth);
 
         // 전송할 message객체 생성
         Message message = new Message();
         // 발신번호 및 수신번호는 반드시 01012345678 형태로 입력되어야 합니다.
         message.setFrom(smsSender);
         message.setTo(phoneNum);
-
-        // 새 인증 코드 생성
-        String certificationCode = Integer.toString((int)(Math.random() * (999999 - 100000 + 1)) + 100000); // 6자리 인증 코드를 랜덤으로 생성
-
-        // 문자인증 엔티티 생성
-        SmsAuth newSmsAuth = SmsAuth.builder()
-                .phoneNum(phoneNum)
-                .authCode(certificationCode)
-                .expirationTime(LocalDateTime.now().plusMinutes(3)) // 3분 후 만료
-                .build();
-        smsAuthRepository.save(newSmsAuth);
-
         message.setText("FarmOn 본인확인 인증번호는 " + certificationCode + "입니다.");
 
         // 문자 전송


### PR DESCRIPTION
## #️⃣연관된 이슈

> #122 

## 📝작업 내용

> 동일한 휴대전화로 인증번호 요청시 2번째부터 문자가 전송되지 않는 오류가 있어서 코드 수정하였습니다. 
기존에는 DB에 저장된 객체를 지우고 새로운 엔티티 객체를 등록하는 방식이었는데 동시성 문제때문에 실행에 문제가 있었던것 같아, 기존 동일한 번호로 요청이 있었다면 해당 객체를 업데이트하는 방식으로 수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 피드백 편하게 주세요!