### PR TITLE
♻️ 전문가 경력 저장방식 수정

### DIFF
--- a/src/main/java/com/backend/farmon/controller/ExpertController.java
+++ b/src/main/java/com/backend/farmon/controller/ExpertController.java
@@ -120,7 +120,6 @@ public class ExpertController {
 
         ExpertCareer updatedExpertCareer = ExpertConverter.updateExpertCareer(expertCareer, expertCareerPostDTO);
         expertCareerRepository.save(updatedExpertCareer);
-        expertCommandService.calculateTotalCareer(updatedExpertCareer.getExpert().getExpertCareerList()); // 경력 업데이트
         // 경력 업데이트
         Expert expert = updatedExpertCareer.getExpert();
         int updatedCareerYears = expertCommandService.calculateTotalCareer(expert.getExpertCareerList());

--- a/src/main/java/com/backend/farmon/controller/ExpertController.java
+++ b/src/main/java/com/backend/farmon/controller/ExpertController.java
@@ -78,6 +78,11 @@ public class ExpertController {
             @RequestBody @Valid ExpertCareerRequest.ExpertCareerPostDTO expertCareerPostDTO,
             @PathVariable(name = "expert-id") Long expertId) {
         ExpertCareer expertCareer = expertCommandService.postExpertCareer(expertId, expertCareerPostDTO);
+        // 경력 업데이트
+        Expert expert = expertRepository.findById(expertId).get();
+        int updatedCareerYears = expertCommandService.calculateTotalCareer(expert.getExpertCareerList());
+        expert.setCareerYears(updatedCareerYears);
+        expertRepository.save(expert);
         return ApiResponse.onSuccess(ExpertConverter.toExpertCareerPostResultDTO(expertCareer));
     }
 
@@ -115,6 +120,12 @@ public class ExpertController {
 
         ExpertCareer updatedExpertCareer = ExpertConverter.updateExpertCareer(expertCareer, expertCareerPostDTO);
         expertCareerRepository.save(updatedExpertCareer);
+        expertCommandService.calculateTotalCareer(updatedExpertCareer.getExpert().getExpertCareerList()); // 경력 업데이트
+        // 경력 업데이트
+        Expert expert = updatedExpertCareer.getExpert();
+        int updatedCareerYears = expertCommandService.calculateTotalCareer(expert.getExpertCareerList());
+        expert.setCareerYears(updatedCareerYears);
+        expertRepository.save(expert);
         return ApiResponse.onSuccess(ExpertConverter.toExpertCareerGetResultDTO(updatedExpertCareer));
     }
 
@@ -132,6 +143,11 @@ public class ExpertController {
                 .orElseThrow(() -> new ExpertCareerHandler(ErrorStatus.EXPERT_CAREER_NOT_FOUND));
         try {
             expertCareerRepository.delete(expertCareer);
+            // 경력 업데이트
+            Expert expert = expertCareer.getExpert();
+            int updatedCareerYears = expertCommandService.calculateTotalCareer(expert.getExpertCareerList());
+            expert.setCareerYears(updatedCareerYears);
+            expertRepository.save(expert);
             return ApiResponse.onSuccess("전문가 경력이 성공적으로 삭제되었습니다.");
         } catch (Exception e) {
             return ApiResponse.onFailure("ERROR_DELETE_EXPERT_CAREER","전문가 경력 삭제에 실패했습니다.",null);

--- a/src/main/java/com/backend/farmon/converter/ExpertConverter.java
+++ b/src/main/java/com/backend/farmon/converter/ExpertConverter.java
@@ -159,15 +159,13 @@ public class ExpertConverter {
     }
 
     public static ExpertListResponse.ExpertProfileViewDTO expertProfileViewDTO(Expert expert) {
-        int career = calculateTotalCareer(expert.getExpertCareerList());
-
         return ExpertListResponse.ExpertProfileViewDTO.builder()
                 .expertId(expert.getId())
                 .profileImg(expert.getProfileImageUrl())
                 .name(expert.getIsNickNameOnly() ? null : expert.getUser().getUserName())
                 .nickName(expert.getNickName())
                 .isNickNameOnly(expert.getIsNickNameOnly())
-                .career(career)
+                .career(expert.getCareerYears())
                 .expertDescription(expert.getExpertDescription())
                 .expertCropCategory(expert.getCrop().getCategory())
                 .expertCropDetail(expert.getCrop().getName())
@@ -248,62 +246,4 @@ public class ExpertConverter {
                 .createdAt(LocalDateTime.now())
                 .build();
     }
-
-    // 경력 기간 계산 함수
-    public static int calculateTotalCareer(List<ExpertCareer> careers) {
-        // 현재 날짜 구하기
-        LocalDate now = LocalDate.now();
-        List<int[]> periods = new ArrayList<>();
-
-        // 각 경력에 대해 기간을 계산하여 periods 리스트에 저장
-        for (ExpertCareer career : careers) {
-            int startYear = career.getStartYear();
-            int endYear = career.getIsOngoing() ? now.getYear() : career.getEndYear();
-
-            // 경력 기간이 1년 이하인 경우 1년으로 처리
-            if (endYear - startYear <= 0) {
-                endYear = startYear + 1;
-            }
-
-            periods.add(new int[]{startYear, endYear});
-        }
-
-        // 경력 기간 병합 및 총합 계산
-        return mergePeriodsAndCalculateTotalYears(periods);
-    }
-
-    // 기간이 겹치는 부분을 제외하고 경력 총합 계산
-    private static int mergePeriodsAndCalculateTotalYears(List<int[]> periods) {
-        // 기간을 시작 연도를 기준으로 오름차순 정렬
-        periods.sort((a, b) -> Integer.compare(a[0], b[0]));
-
-        int totalYears = 0;
-        int currentStart = -1;
-        int currentEnd = -1;
-
-        for (int[] period : periods) {
-            int startYear = period[0];
-            int endYear = period[1];
-
-            // 겹치는 기간이 없으면 경력 추가
-            if (startYear > currentEnd) {
-                if (currentStart != -1) {
-                    totalYears += currentEnd - currentStart;
-                }
-                currentStart = startYear;
-                currentEnd = endYear;
-            } else {
-                // 겹치는 기간이 있으면 합쳐서 끝 연도를 갱신
-                currentEnd = Math.max(currentEnd, endYear);
-            }
-        }
-
-        // 마지막 기간 추가
-        if (currentStart != -1) {
-            totalYears += currentEnd - currentStart;
-        }
-
-        return totalYears;
-    }
-
 }

--- a/src/main/java/com/backend/farmon/domain/Expert.java
+++ b/src/main/java/com/backend/farmon/domain/Expert.java
@@ -36,9 +36,9 @@ public class Expert extends BaseEntity {
     private String additionalInformation; // 전문가 추가정보
 
     private Float rating;
+
     @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
     private Integer careerYears;
-
 
     private String availableRange; //활동 가능 범위
 
@@ -106,6 +106,13 @@ public class Expert extends BaseEntity {
         this.user = user;
         if (user != null) {
             user.setExpert(this);  // 반대편도 설정
+        }
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (careerYears == null) {
+            careerYears = 0;
         }
     }
 }

--- a/src/main/java/com/backend/farmon/domain/Expert.java
+++ b/src/main/java/com/backend/farmon/domain/Expert.java
@@ -36,7 +36,9 @@ public class Expert extends BaseEntity {
     private String additionalInformation; // 전문가 추가정보
 
     private Float rating;
+    @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
     private Integer careerYears;
+
 
     private String availableRange; //활동 가능 범위
 

--- a/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandService.java
+++ b/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandService.java
@@ -26,4 +26,6 @@ public interface ExpertCommandService {
                                                              List<MultipartFile> ImgList, MultipartFile thumbnailImg);
     String updateImageSrcWithS3(String text, List<PortfolioImg> newImageUrls);
     PortfolioResponse.DeletePortfolioResultDTO deletePortfolio(Long portfolioId);
+    int calculateTotalCareer(List<ExpertCareer> careers);
+    int mergePeriodsAndCalculateTotalYears(List<int[]> periods);
 }

--- a/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandServiceImpl.java
+++ b/src/main/java/com/backend/farmon/service/ExpertService/ExpertCommandServiceImpl.java
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -319,5 +320,66 @@ public class ExpertCommandServiceImpl implements ExpertCommandService {
         } catch (Exception e) {
             throw new PortfolioHandler(ErrorStatus.PORTFOLIO_DELETE_FAILED);
         }
+    }
+
+    // 경력 기간 계산 함수
+    @Override
+    @Transactional
+    public int calculateTotalCareer(List<ExpertCareer> careers) {
+        // 현재 날짜 구하기
+        LocalDate now = LocalDate.now();
+        List<int[]> periods = new ArrayList<>();
+
+        // 각 경력에 대해 기간을 계산하여 periods 리스트에 저장
+        for (ExpertCareer career : careers) {
+            int startYear = career.getStartYear();
+            int endYear = career.getIsOngoing() ? now.getYear() : career.getEndYear();
+
+            // 경력 기간이 1년 이하인 경우 1년으로 처리
+            if (endYear - startYear <= 0) {
+                endYear = startYear + 1;
+            }
+
+            periods.add(new int[]{startYear, endYear});
+        }
+
+        // 경력 기간 병합 및 총합 계산
+        return mergePeriodsAndCalculateTotalYears(periods);
+    }
+
+    // 기간이 겹치는 부분을 제외하고 경력 총합 계산
+    @Override
+    @Transactional
+    public int mergePeriodsAndCalculateTotalYears(List<int[]> periods) {
+        // 기간을 시작 연도를 기준으로 오름차순 정렬
+        periods.sort((a, b) -> Integer.compare(a[0], b[0]));
+
+        int totalYears = 0;
+        int currentStart = -1;
+        int currentEnd = -1;
+
+        for (int[] period : periods) {
+            int startYear = period[0];
+            int endYear = period[1];
+
+            // 겹치는 기간이 없으면 경력 추가
+            if (startYear > currentEnd) {
+                if (currentStart != -1) {
+                    totalYears += currentEnd - currentStart;
+                }
+                currentStart = startYear;
+                currentEnd = endYear;
+            } else {
+                // 겹치는 기간이 있으면 합쳐서 끝 연도를 갱신
+                currentEnd = Math.max(currentEnd, endYear);
+            }
+        }
+
+        // 마지막 기간 추가
+        if (currentStart != -1) {
+            totalYears += currentEnd - currentStart;
+        }
+
+        return totalYears;
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

>

## 📝작업 내용

> 기존에 전문가 프로필 조회할때 일일히 경력년도 계산해서 보여주던 방식을 경력 등록할때마다 전문가 엔티티 careerYears에 저장하는 방식으로 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 피드백 편하게 주세요!