### PR TITLE
🐛[Fix] 채팅방 페이징 조회 totalPages, totalElements 오류 수정

### DIFF
--- a/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/backend/farmon/repository/ChatRoomReposiotry/ChatRoomRepositoryImpl.java
@@ -13,6 +13,9 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
@@ -22,58 +25,25 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
     QUser farmer = QUser.user;
     QExpert expert = QExpert.expert;
 
+    // userId, 역할, 검색어가 일치하는 채팅방 페이징 조회
     @Override
     public Page<ChatRoom> findChatRoomsByUserIdAndRoleAndSearch(Long userId, String role, String searchName, Pageable pageable) {
-        BooleanBuilder builder = new BooleanBuilder();
-
-        // userId와 연관된 채팅방 조회
-        builder.and(chatRoom.farmer.id.eq(userId).or(chatRoom.expert.user.id.eq(userId)));
-
-        // role에 따른 조건 추가
-        if ("FARMER".equalsIgnoreCase(role)) {
-            builder.and(chatRoom.farmer.id.eq(userId));
-        } else if ("EXPERT".equalsIgnoreCase(role)) {
-            builder.and(chatRoom.expert.user.id.eq(userId));
-        } else {
-            throw new IllegalArgumentException("Invalid role: " + role);
-        }
-
-        // 텍스트, 이미지 메시지만 조회
-        builder.and(chatMessage.type.in(ChatMessageType.TEXT, ChatMessageType.IMAGE));
-
-        // 검색어 조건 (여섯 가지 중 하나라도 포함되면 조회)
-        if (searchName != null && !searchName.trim().isEmpty()) {
-            BooleanBuilder searchCondition = new BooleanBuilder();
-            searchCondition.or(chatRoom.farmer.userName.containsIgnoreCase(searchName)); // 농업인 사용자명 검색
-            searchCondition.or(chatRoom.expert.nickName.containsIgnoreCase(searchName)); // 전문가 닉네임 검색
-            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(false).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시하지 않을 경우, 원래 사용자명도 검색
-            searchCondition.or(chatRoom.estimate.crop.category.containsIgnoreCase(searchName)); // 작물 카테고리로 검색
-            searchCondition.or(chatRoom.estimate.crop.name.containsIgnoreCase(searchName)); // 작물 디테일 이름으로 검색
-            searchCondition.or(chatRoom.estimate.category.containsIgnoreCase(searchName)); // 견적 분야로 검색
-
-            builder.and(searchCondition); // 전체 조건에 추가
-        }
-
-        // 데이터 조회 쿼리
-        QueryResults<ChatRoom> results = queryFactory
-                .selectFrom(chatRoom)
-                .join(chatMessage).on(chatMessage.chatRoom.id.eq(chatRoom.id))
-                .where(builder)
-                .orderBy(chatRoom.createdAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetchResults();
-
-        // Page 객체 반환
-        return new PageImpl<>(results.getResults(), pageable, results.getTotal());
+        BooleanBuilder builder = buildBaseQuery(userId, role, searchName, false); // `isUnread = false` (모든 메시지)
+        return fetchPagedChatRooms(builder, pageable);
     }
 
-    // userId와 연관된 채팅방 중 안 읽음 메시지가 존재하는 채팅방만 페이징 조회
+    // userId, 역할, 검색어가 일치하는 안 읽은 채팅방 페이징 조회
     @Override
     public Page<ChatRoom> findUnReadChatRoomsByUserIdAndRoleAndSearch(Long userId, String role, String searchName, Pageable pageable) {
+        BooleanBuilder builder = buildBaseQuery(userId, role, searchName, true); // `isUnread = true` (읽지 않은 메시지)
+        return fetchPagedChatRooms(builder, pageable);
+    }
+
+    // 채팅방 페이징 조건 빌더
+    private BooleanBuilder buildBaseQuery(Long userId, String role, String searchName, boolean isUnread) {
         BooleanBuilder builder = new BooleanBuilder();
 
-        // role에 따른 조건 추가
+        // 역할(Role) 설정
         if ("FARMER".equalsIgnoreCase(role)) {
             builder.and(chatRoom.farmer.id.eq(userId));
         } else if ("EXPERT".equalsIgnoreCase(role)) {
@@ -82,35 +52,65 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
             throw new IllegalArgumentException("Invalid role: " + role);
         }
 
-        // 안 읽은 텍스트, 이미지 메시지만 조회
-        builder.and(chatMessage.isRead.isFalse());
-        builder.and(chatMessage.type.in(ChatMessageType.TEXT, ChatMessageType.IMAGE));
-
-        // 검색어 조건 (여섯 가지 중 하나라도 포함되면 조회)
-        if (searchName != null && !searchName.trim().isEmpty()) {
-            BooleanBuilder searchCondition = new BooleanBuilder();
-            searchCondition.or(chatRoom.farmer.userName.containsIgnoreCase(searchName)); // 농업인 사용자명 검색
-            searchCondition.or(chatRoom.expert.nickName.containsIgnoreCase(searchName)); // 전문가 닉네임 검색
-            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(false).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName))); // 전문가가 닉네임만 표시하지 않을 경우, 원래 사용자명도 검색
-            searchCondition.or(chatRoom.estimate.crop.category.containsIgnoreCase(searchName)); // 작물 카테고리로 검색
-            searchCondition.or(chatRoom.estimate.crop.name.containsIgnoreCase(searchName)); // 작물 디테일 이름으로 검색
-            searchCondition.or(chatRoom.estimate.category.containsIgnoreCase(searchName)); // 견적 분야로 검색
-
-            builder.and(searchCondition); // 전체 조건에 추가
+        // 안 읽은 메시지만 조회하는 경우
+        if (isUnread) {
+            builder.and(chatMessage.isRead.isFalse());
         }
 
+        // 메시지 유형 필터링 (TEXT, IMAGE만 포함)
+        builder.and(chatMessage.type.in(ChatMessageType.TEXT, ChatMessageType.IMAGE));
+
+        // 검색어 필터 추가
+        if (searchName != null && !searchName.trim().isEmpty()) {
+            BooleanBuilder searchCondition = new BooleanBuilder();
+            searchCondition.or(chatRoom.farmer.userName.containsIgnoreCase(searchName));
+            searchCondition.or(chatRoom.expert.nickName.containsIgnoreCase(searchName));
+            searchCondition.or(chatRoom.expert.isNickNameOnly.eq(false).and(chatRoom.expert.user.userName.containsIgnoreCase(searchName)));
+            searchCondition.or(chatRoom.estimate.crop.category.containsIgnoreCase(searchName));
+            searchCondition.or(chatRoom.estimate.crop.name.containsIgnoreCase(searchName));
+            searchCondition.or(chatRoom.estimate.category.containsIgnoreCase(searchName));
+
+            builder.and(searchCondition);
+        }
+
+        return builder;
+    }
+
+   // userId와 연관된 페이징된 채팅방 목록 조회
+    private Page<ChatRoom> fetchPagedChatRooms(BooleanBuilder builder, Pageable pageable) {
         // 데이터 조회 쿼리
-        QueryResults<ChatRoom> results = queryFactory
-                .selectFrom(chatRoom)
+        List<ChatRoom> chatRooms = fetchChatRooms(builder, pageable);
+
+        // 개수 조회 쿼리
+        long total = countChatRooms(builder);
+
+        // Page 객체 반환
+        return new PageImpl<>(chatRooms, pageable, total);
+    }
+
+    // userId와 연관된 채팅방 리스트 조회
+    private List<ChatRoom> fetchChatRooms(BooleanBuilder builder, Pageable pageable) {
+        return queryFactory
+                .selectDistinct(chatRoom)  // 중복 제거
+                .from(chatRoom)
                 .join(chatMessage).on(chatMessage.chatRoom.id.eq(chatRoom.id))
                 .where(builder)
                 .orderBy(chatRoom.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .fetchResults();
+                .fetch();
+    }
 
-        // Page 객체 반환
-        return new PageImpl<>(results.getResults(), pageable, results.getTotal());
+    // 총 채팅방 개수
+    private long countChatRooms(BooleanBuilder builder) {
+        return Optional.ofNullable(
+                queryFactory
+                        .select(chatRoom.id.countDistinct())  // DISTINCT 적용
+                        .from(chatRoom)
+                        .join(chatMessage).on(chatMessage.chatRoom.id.eq(chatRoom.id))
+                        .where(builder)
+                        .fetchOne()
+        ).orElse(0L);
     }
 
     // 채팅방에서 농업인 여부


### PR DESCRIPTION
## 📝작업 내용
채팅방 페이지 조회 시, 중복된 데이터가 포함되어 totalPages 및 totalElements 값이 실제 데이터 개수와 일치하지 않는 문제를 수정했습니다.

## 💬리뷰 요구사항(선택)
> api 연동을 위해 일단 머지하겠습니다.