### PR TITLE
🐛[Fix] 채팅방 생성 시에는 AOP 권한 검증 생략하도록 수정

### DIFF
--- a/src/main/java/com/backend/farmon/aspects/ChatAuthorizationAspect.java
+++ b/src/main/java/com/backend/farmon/aspects/ChatAuthorizationAspect.java
@@ -2,6 +2,7 @@ package com.backend.farmon.aspects;
 
 import com.backend.farmon.config.security.UserAuthorizationUtil;
 import com.backend.farmon.service.ValidationService.ValidationService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -9,6 +10,10 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Arrays;
 
 
 @Slf4j
@@ -26,9 +31,17 @@ public class ChatAuthorizationAspect {
     // 채팅방과 연관관계가 있는 사용자인지 & 역할이 일치하지는지 검증
     @Around(value = "aspectChatRoom() && args(userId, chatRoomId, ..)", argNames = "joinPoint,userId,chatRoomId")
     public Object validateAuthInChatRoom(ProceedingJoinPoint joinPoint, Long userId, Long chatRoomId) throws Throwable {
-        validationService.validateAuthInChatRoom(userId, chatRoomId, userAuthorizationUtil.getCurrentUserRole());
-        log.info("AOP를 이용한 채팅방 접근 권한 검증 완료");
+        // 현재 요청의 HTTP 메서드 확인
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+        String method = request.getMethod();
 
+        // POST 요청이 아닐 경우에만 검증 수행
+        if (!"POST".equalsIgnoreCase(method)) {
+            validationService.validateAuthInChatRoom(userId, chatRoomId, userAuthorizationUtil.getCurrentUserRole());
+            log.info("AOP를 이용한 채팅방 접근 권한 검증 완료");
+        } else {
+            log.info("POST 요청(채팅방 생성)이므로 권한 검증을 생략");
+        }
         return joinPoint.proceed();
     }
 }


### PR DESCRIPTION
## 📝작업 내용

AOP 파라미터가 String 타입으로 받는 것이 아닌, Long으로 받기 때문에 estimateId가 chatRoomId로 바인딩 되어 오류 발생 -> POST 요청 시(채팅방 생성)에는 AOP 권한 검증 생략하도록 수정